### PR TITLE
tune Mattermost alerts

### DIFF
--- a/.github/workflows/zhook.yml
+++ b/.github/workflows/zhook.yml
@@ -22,8 +22,18 @@ jobs:
     steps:
     - uses: openziti/ziti-mattermost-action-py@main
       if: |
-        (github.event_name != 'pull_request_review')
-        || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        env.ZHOOK_URL != null
+        && !(
+          github.event_name == 'issue_comment'
+          && github.event.sender.login == 'vercel[bot]'
+          && contains(github.event.comment.body, 'Building')
+        )
+        && (
+          github.event_name != 'pull_request_review'
+          || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        )
+      env:
+        ZHOOK_URL: ${{ secrets.ZHOOK_URL }}
       with:
         zitiId: ${{ secrets.ZITI_MATTERMOST_IDENTITY }}
         webhookUrl: ${{ secrets.ZHOOK_URL }}

--- a/.github/workflows/zhook.yml
+++ b/.github/workflows/zhook.yml
@@ -26,7 +26,7 @@ jobs:
         && !(
           github.event_name == 'issue_comment'
           && github.event.sender.login == 'vercel[bot]'
-          && contains(github.event.comment.body, 'Building')
+          && (contains(github.event.comment.body, 'Building') || contains(github.event.comment.body, 'Ignored'))
         )
         && (
           github.event_name != 'pull_request_review'


### PR DESCRIPTION
* stop trying futilely to send Mattermost alerts in zrok forks and 
* suppress alerts for Vercel "building" comments on PRs