### PR TITLE
stop overriding the Vercel ignore command 

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -6,5 +6,5 @@
     },
     "cleanUrls": false,
     "public": true,
-    "ignoreCommand": "[[ \"${VERCEL_GIT_COMMIT_REF}\" =~ ^(gh-pages)$ ]] || git diff --quiet HEAD^ HEAD -- ../website/ ../docs/"
+    "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ../website/ ../docs/"
 }


### PR DESCRIPTION
because zrok `gh-pages` branch never contains the vercel.json file. Instead, I configured the zrok project in Vercel to ignore commits in `gh-pages` branch:

```bash
[[ "${VERCEL_GIT_COMMIT_REF}" =~ ^(gh-pages)$ ]]
```

Vercel will override this ignore command when the `vercel.json` file is present in a normal branch.