### PR TITLE
Improved URL Parsing

### DIFF
--- a/cmd/zrok/reserve.go
+++ b/cmd/zrok/reserve.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"net/url"
 	"strings"
 )
 
@@ -48,17 +47,14 @@ func (cmd *reserveCommand) run(_ *cobra.Command, args []string) {
 	var target string
 	switch cmd.backendMode {
 	case "proxy":
-		targetEndpoint, err := url.Parse(args[1])
+		v, err := parseUrl(args[1])
 		if err != nil {
 			if !panicInstead {
 				tui.Error("invalid target endpoint URL", err)
 			}
 			panic(err)
 		}
-		if targetEndpoint.Scheme == "" {
-			targetEndpoint.Scheme = "https"
-		}
-		target = targetEndpoint.String()
+		target = v
 
 	case "web":
 		target = args[1]

--- a/cmd/zrok/sharePrivate.go
+++ b/cmd/zrok/sharePrivate.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -56,17 +55,14 @@ func (cmd *sharePrivateCommand) run(_ *cobra.Command, args []string) {
 
 	switch cmd.backendMode {
 	case "proxy":
-		targetEndpoint, err := url.Parse(args[0])
+		v, err := parseUrl(args[0])
 		if err != nil {
 			if !panicInstead {
 				tui.Error("invalid target endpoint URL", err)
 			}
 			panic(err)
 		}
-		if targetEndpoint.Scheme == "" {
-			targetEndpoint.Scheme = "https"
-		}
-		target = targetEndpoint.String()
+		target = v
 
 	case "web":
 		target = args[0]

--- a/cmd/zrok/sharePublic.go
+++ b/cmd/zrok/sharePublic.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -58,17 +57,14 @@ func (cmd *sharePublicCommand) run(_ *cobra.Command, args []string) {
 
 	switch cmd.backendMode {
 	case "proxy":
-		targetEndpoint, err := url.Parse(args[0])
+		v, err := parseUrl(args[0])
 		if err != nil {
 			if !panicInstead {
 				tui.Error("invalid target endpoint URL", err)
 			}
 			panic(err)
 		}
-		if targetEndpoint.Scheme == "" {
-			targetEndpoint.Scheme = "https"
-		}
-		target = targetEndpoint.String()
+		target = v
 
 	case "web":
 		target = args[0]

--- a/cmd/zrok/util.go
+++ b/cmd/zrok/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/pkg/errors"
 	"net/url"
 	"os"
 	"strconv"
@@ -21,7 +22,13 @@ func mustGetAdminAuth() runtime.ClientAuthInfoWriter {
 func parseUrl(in string) (string, error) {
 	// parse port-only urls
 	if iv, err := strconv.ParseInt(in, 10, 0); err == nil {
-		return fmt.Sprintf("http://127.0.0.1:%d", iv), nil
+		if iv > 0 && iv < 65536 {
+			if iv == 443 {
+				return fmt.Sprintf("https://127.0.0.1:%d", iv), nil
+			}
+			return fmt.Sprintf("http://127.0.0.1:%d", iv), nil
+		}
+		return "", errors.Errorf("ports must be between 1 and 65536; %d is not", iv)
 	}
 
 	// make sure either https:// or http:// was specified

--- a/cmd/zrok/util.go
+++ b/cmd/zrok/util.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
+	"net/url"
 	"os"
+	"strconv"
+	"strings"
 )
 
 func mustGetAdminAuth() runtime.ClientAuthInfoWriter {
@@ -12,4 +16,24 @@ func mustGetAdminAuth() runtime.ClientAuthInfoWriter {
 		panic("please set ZROK_ADMIN_TOKEN to a valid admin token for your zrok instance")
 	}
 	return httptransport.APIKeyAuth("X-TOKEN", "header", adminToken)
+}
+
+func parseUrl(in string) (string, error) {
+	// parse port-only urls
+	if iv, err := strconv.ParseInt(in, 10, 0); err == nil {
+		return fmt.Sprintf("http://127.0.0.1:%d", iv), nil
+	}
+
+	// make sure either https:// or http:// was specified
+	if !strings.HasPrefix(in, "https://") && !strings.HasPrefix(in, "http://") {
+		in = "http://" + in
+	}
+
+	// parse the url
+	targetEndpoint, err := url.Parse(in)
+	if err != nil {
+		return "", err
+	}
+
+	return targetEndpoint.String(), nil
 }

--- a/cmd/zrok/util.go
+++ b/cmd/zrok/util.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/pkg/errors"
+	"math"
 	"net/url"
 	"os"
 	"strconv"
@@ -22,13 +23,13 @@ func mustGetAdminAuth() runtime.ClientAuthInfoWriter {
 func parseUrl(in string) (string, error) {
 	// parse port-only urls
 	if iv, err := strconv.ParseInt(in, 10, 0); err == nil {
-		if iv > 0 && iv < 65536 {
+		if iv > 0 && iv <= math.MaxUint16 {
 			if iv == 443 {
 				return fmt.Sprintf("https://127.0.0.1:%d", iv), nil
 			}
 			return fmt.Sprintf("http://127.0.0.1:%d", iv), nil
 		}
-		return "", errors.Errorf("ports must be between 1 and 65536; %d is not", iv)
+		return "", errors.Errorf("ports must be between 1 and %d; %d is not", math.MaxUint16, iv)
 	}
 
 	// make sure either https:// or http:// was specified


### PR DESCRIPTION
Corrects this issue:

https://github.com/openziti/zrok/issues/211

And also supports URLs like:

`9090` -> http://127.0.0.1:9090
`localhost:9090` -> http://127.0.0.1:9090
`https://localhost:9090` -> https://localhost:9090

Should align more closely with what users will likely expect.