### PR TITLE
align Docusaurus trailing slashes: redirects and canonicals

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,6 +11,7 @@ const config = {
   tagline: 'Globally distributed reverse proxy',
   url: 'https://docs.zrok.io',
   baseUrl: '/',
+  trailingSlash: true,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/space-ziggy.png',


### PR DESCRIPTION
This one is tricky, but I think I've got it figured. The problem I'm solving is that Algolia ignores all pages with the Docusaurus default `trailingSlash: undefined` because all pages either:
* don't have a trailing slash and therefore redirect to the same path with a trailing slash, or
* do have trailing slash and therefore don't match their canonical URL without the trailing slash.

The solution is to add a trailing slash to the canonical URL.