### PR TITLE
add release candidate container image

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   ubuntu-build:
+    name: Build Linux AMD64 CLI
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -52,3 +53,63 @@ jobs:
           name: linux-amd64
           path: ${{ steps.solve_go_bin.outputs.go_bin }}/zrok
           if-no-files-found: error
+  # build a release candidate container image for branches named "main" or like "v*"
+  rc-container-build:
+    needs: ubuntu-build
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/v')
+    name: Build Release Candidate Container Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set a container image tag from the branch name
+        id: slug
+        run: |
+          echo branch_tag=$(sed 's/[^a-z0-9_-]/__/gi' <<< "${GITHUB_REF#refs/heads/}") >> $GITHUB_OUTPUT
+
+      - name: Checkout Workspace
+        uses: actions/checkout@v3
+
+      - name: Download Branch Build Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-amd64
+          path: ./dist/amd64/linux/
+
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: amd64,arm64
+
+      - name: Set Up Docker BuildKit
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_API_USER }}
+          password: ${{ secrets.DOCKER_HUB_API_TOKEN }}
+
+      - name: Set Up Container Image Tags for zrok CLI Container
+        env:
+          # RELEASE_REPO: openziti/zrok
+          RELEASE_REPO: kbinghamnetfoundry/zrok
+          ZROK_VERSION: ${{ steps.slug.outputs.branch_tag }}
+        id: tagprep_cli
+        run: |
+          DOCKER_TAGS=""
+          DOCKER_TAGS="${RELEASE_REPO}:${ZROK_VERSION}"
+          echo "DEBUG: DOCKER_TAGS=${DOCKER_TAGS}"
+          echo DOCKER_TAGS="${DOCKER_TAGS}" >> $GITHUB_OUTPUT
+
+      - name: Build & Push Linux AMD64 CLI Container Image to Hub
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ${{ github.workspace }}/
+          file: ${{ github.workspace }}/docker/images/zrok/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ steps.tagprep_cli.outputs.DOCKER_TAGS }}
+          build-args: |
+            DOCKER_BUILD_DIR=./docker/images/zrok
+            ARTIFACTS_DIR=./dist
+          push: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -91,8 +91,7 @@ jobs:
 
       - name: Set Up Container Image Tags for zrok CLI Container
         env:
-          # RELEASE_REPO: openziti/zrok
-          RELEASE_REPO: kbinghamnetfoundry/zrok
+          RELEASE_REPO: openziti/zrok
           ZROK_VERSION: ${{ steps.slug.outputs.branch_tag }}
         id: tagprep_cli
         run: |


### PR DESCRIPTION
enables canary container deployments that are subscribed to branch `main` or an rc branch, e.g. `v0.4_bandwidth_limits`.

```bash
$ docker run --rm openziti/zrok:main version     
               _    
 _____ __ ___ | | __
|_  / '__/ _ \| |/ /
 / /| | | (_) |   < 
/___|_|  \___/|_|\_\

refs/heads/main [e33d95e4fa287e9a54975e7350d869335b503662]
```