### PR TITLE
Fix for Edge Management API Usage in Limits Agent

### DIFF
--- a/controller/limits/accountWarningAction.go
+++ b/controller/limits/accountWarningAction.go
@@ -2,7 +2,6 @@ package limits
 
 import (
 	"github.com/jmoiron/sqlx"
-	"github.com/openziti/edge-api/rest_management_api_client"
 	"github.com/openziti/zrok/controller/emailUi"
 	"github.com/openziti/zrok/controller/store"
 	"github.com/openziti/zrok/util"
@@ -11,16 +10,15 @@ import (
 )
 
 type accountWarningAction struct {
-	str  *store.Store
-	edge *rest_management_api_client.ZitiEdgeManagement
-	cfg  *emailUi.Config
+	str *store.Store
+	cfg *emailUi.Config
 }
 
-func newAccountWarningAction(cfg *emailUi.Config, str *store.Store, edge *rest_management_api_client.ZitiEdgeManagement) *accountWarningAction {
-	return &accountWarningAction{str, edge, cfg}
+func newAccountWarningAction(cfg *emailUi.Config, str *store.Store) *accountWarningAction {
+	return &accountWarningAction{str, cfg}
 }
 
-func (a *accountWarningAction) HandleAccount(acct *store.Account, rxBytes, txBytes int64, limit *BandwidthPerPeriod, trx *sqlx.Tx) error {
+func (a *accountWarningAction) HandleAccount(acct *store.Account, rxBytes, txBytes int64, limit *BandwidthPerPeriod, _ *sqlx.Tx) error {
 	logrus.Infof("warning '%v'", acct.Email)
 
 	if a.cfg != nil {

--- a/controller/limits/agent.go
+++ b/controller/limits/agent.go
@@ -41,6 +41,7 @@ func NewAgent(cfg *Config, ifxCfg *metrics.InfluxConfig, zCfg *zrokEdgeSdk.Confi
 		str:                str,
 		queue:              make(chan *metrics.Usage, 1024),
 		acctWarningActions: []AccountAction{newAccountWarningAction(emailCfg, str)},
+		acctLimitActions:   []AccountAction{newAccountLimitAction(str, zCfg)},
 		acctRelaxActions:   []AccountAction{newAccountRelaxAction(str, zCfg)},
 		envWarningActions:  []EnvironmentAction{newEnvironmentWarningAction(emailCfg, str)},
 		envLimitActions:    []EnvironmentAction{newEnvironmentLimitAction(str, zCfg)},

--- a/controller/limits/agent.go
+++ b/controller/limits/agent.go
@@ -34,25 +34,20 @@ type Agent struct {
 }
 
 func NewAgent(cfg *Config, ifxCfg *metrics.InfluxConfig, zCfg *zrokEdgeSdk.Config, emailCfg *emailUi.Config, str *store.Store) (*Agent, error) {
-	edge, err := zrokEdgeSdk.Client(zCfg)
-	if err != nil {
-		return nil, err
-	}
 	a := &Agent{
 		cfg:                cfg,
 		ifx:                newInfluxReader(ifxCfg),
 		zCfg:               zCfg,
 		str:                str,
 		queue:              make(chan *metrics.Usage, 1024),
-		acctWarningActions: []AccountAction{newAccountWarningAction(emailCfg, str, edge)},
-		acctLimitActions:   []AccountAction{newAccountLimitAction(str, edge)},
-		acctRelaxActions:   []AccountAction{newAccountRelaxAction(str, edge)},
-		envWarningActions:  []EnvironmentAction{newEnvironmentWarningAction(emailCfg, str, edge)},
-		envLimitActions:    []EnvironmentAction{newEnvironmentLimitAction(str, edge)},
-		envRelaxActions:    []EnvironmentAction{newEnvironmentRelaxAction(str, edge)},
-		shrWarningActions:  []ShareAction{newShareWarningAction(emailCfg, str, edge)},
-		shrLimitActions:    []ShareAction{newShareLimitAction(str, edge)},
-		shrRelaxActions:    []ShareAction{newShareRelaxAction(str, edge)},
+		acctWarningActions: []AccountAction{newAccountWarningAction(emailCfg, str)},
+		acctRelaxActions:   []AccountAction{newAccountRelaxAction(str, zCfg)},
+		envWarningActions:  []EnvironmentAction{newEnvironmentWarningAction(emailCfg, str)},
+		envLimitActions:    []EnvironmentAction{newEnvironmentLimitAction(str, zCfg)},
+		envRelaxActions:    []EnvironmentAction{newEnvironmentRelaxAction(str, zCfg)},
+		shrWarningActions:  []ShareAction{newShareWarningAction(emailCfg, str)},
+		shrLimitActions:    []ShareAction{newShareLimitAction(str, zCfg)},
+		shrRelaxActions:    []ShareAction{newShareRelaxAction(str, zCfg)},
 		close:              make(chan struct{}),
 		join:               make(chan struct{}),
 	}

--- a/controller/limits/environmentWarningAction.go
+++ b/controller/limits/environmentWarningAction.go
@@ -2,7 +2,6 @@ package limits
 
 import (
 	"github.com/jmoiron/sqlx"
-	"github.com/openziti/edge-api/rest_management_api_client"
 	"github.com/openziti/zrok/controller/emailUi"
 	"github.com/openziti/zrok/controller/store"
 	"github.com/openziti/zrok/util"
@@ -11,13 +10,12 @@ import (
 )
 
 type environmentWarningAction struct {
-	str  *store.Store
-	edge *rest_management_api_client.ZitiEdgeManagement
-	cfg  *emailUi.Config
+	str *store.Store
+	cfg *emailUi.Config
 }
 
-func newEnvironmentWarningAction(cfg *emailUi.Config, str *store.Store, edge *rest_management_api_client.ZitiEdgeManagement) *environmentWarningAction {
-	return &environmentWarningAction{str, edge, cfg}
+func newEnvironmentWarningAction(cfg *emailUi.Config, str *store.Store) *environmentWarningAction {
+	return &environmentWarningAction{str, cfg}
 }
 
 func (a *environmentWarningAction) HandleEnvironment(env *store.Environment, rxBytes, txBytes int64, limit *BandwidthPerPeriod, trx *sqlx.Tx) error {

--- a/controller/limits/shareLimitAction.go
+++ b/controller/limits/shareLimitAction.go
@@ -2,7 +2,6 @@ package limits
 
 import (
 	"github.com/jmoiron/sqlx"
-	"github.com/openziti/edge-api/rest_management_api_client"
 	"github.com/openziti/zrok/controller/store"
 	"github.com/openziti/zrok/controller/zrokEdgeSdk"
 	"github.com/sirupsen/logrus"
@@ -10,11 +9,11 @@ import (
 
 type shareLimitAction struct {
 	str  *store.Store
-	edge *rest_management_api_client.ZitiEdgeManagement
+	zCfg *zrokEdgeSdk.Config
 }
 
-func newShareLimitAction(str *store.Store, edge *rest_management_api_client.ZitiEdgeManagement) *shareLimitAction {
-	return &shareLimitAction{str, edge}
+func newShareLimitAction(str *store.Store, zCfg *zrokEdgeSdk.Config) *shareLimitAction {
+	return &shareLimitAction{str, zCfg}
 }
 
 func (a *shareLimitAction) HandleShare(shr *store.Share, _, _ int64, _ *BandwidthPerPeriod, trx *sqlx.Tx) error {
@@ -25,7 +24,12 @@ func (a *shareLimitAction) HandleShare(shr *store.Share, _, _ int64, _ *Bandwidt
 		return err
 	}
 
-	if err := zrokEdgeSdk.DeleteServicePoliciesDial(env.ZId, shr.Token, a.edge); err != nil {
+	edge, err := zrokEdgeSdk.Client(a.zCfg)
+	if err != nil {
+		return err
+	}
+
+	if err := zrokEdgeSdk.DeleteServicePoliciesDial(env.ZId, shr.Token, edge); err != nil {
 		return err
 	}
 	logrus.Infof("removed dial service policy for '%v'", shr.Token)

--- a/controller/limits/shareRelaxAction.go
+++ b/controller/limits/shareRelaxAction.go
@@ -11,24 +11,29 @@ import (
 
 type shareRelaxAction struct {
 	str  *store.Store
-	edge *rest_management_api_client.ZitiEdgeManagement
+	zCfg *zrokEdgeSdk.Config
 }
 
-func newShareRelaxAction(str *store.Store, edge *rest_management_api_client.ZitiEdgeManagement) *shareRelaxAction {
-	return &shareRelaxAction{str, edge}
+func newShareRelaxAction(str *store.Store, zCfg *zrokEdgeSdk.Config) *shareRelaxAction {
+	return &shareRelaxAction{str, zCfg}
 }
 
 func (a *shareRelaxAction) HandleShare(shr *store.Share, _, _ int64, _ *BandwidthPerPeriod, trx *sqlx.Tx) error {
 	logrus.Infof("relaxing '%v'", shr.Token)
 
 	if !shr.Deleted {
+		edge, err := zrokEdgeSdk.Client(a.zCfg)
+		if err != nil {
+			return err
+		}
+
 		switch shr.ShareMode {
 		case "public":
-			if err := relaxPublicShare(a.str, a.edge, shr, trx); err != nil {
+			if err := relaxPublicShare(a.str, edge, shr, trx); err != nil {
 				return err
 			}
 		case "private":
-			if err := relaxPrivateShare(a.str, a.edge, shr, trx); err != nil {
+			if err := relaxPrivateShare(a.str, edge, shr, trx); err != nil {
 				return err
 			}
 		}

--- a/controller/limits/shareWarningAction.go
+++ b/controller/limits/shareWarningAction.go
@@ -2,7 +2,6 @@ package limits
 
 import (
 	"github.com/jmoiron/sqlx"
-	"github.com/openziti/edge-api/rest_management_api_client"
 	"github.com/openziti/zrok/controller/emailUi"
 	"github.com/openziti/zrok/controller/store"
 	"github.com/openziti/zrok/util"
@@ -11,13 +10,12 @@ import (
 )
 
 type shareWarningAction struct {
-	str  *store.Store
-	edge *rest_management_api_client.ZitiEdgeManagement
-	cfg  *emailUi.Config
+	str *store.Store
+	cfg *emailUi.Config
 }
 
-func newShareWarningAction(cfg *emailUi.Config, str *store.Store, edge *rest_management_api_client.ZitiEdgeManagement) *shareWarningAction {
-	return &shareWarningAction{str, edge, cfg}
+func newShareWarningAction(cfg *emailUi.Config, str *store.Store) *shareWarningAction {
+	return &shareWarningAction{str, cfg}
 }
 
 func (a *shareWarningAction) HandleShare(shr *store.Share, rxBytes, txBytes int64, limit *BandwidthPerPeriod, trx *sqlx.Tx) error {


### PR DESCRIPTION
The limits agent was trying to be clever and re-use an edge management API session that was allocated at startup. This was causing issues.

Limits actions now allocate an edge management API session whenever they need to talk to the Ziti controller.