### PR TITLE
Multiple Changes for v0.4.8

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.0
+          go-version: '>=1.21.3'
 
       - name: setup-node
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.21.0'
+          go-version: '>=1.21.3'
           cache: true
 
       - uses: actions/setup-node@v3
@@ -43,7 +43,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --skip-publish --config .goreleaser-linux.yml
+          args: release --skip=publish --config .goreleaser-linux.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -66,12 +66,12 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.21.0'
+          go-version: '>=1.21.3'
           cache: true
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - run: npm install
         working-directory: ui
@@ -85,7 +85,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --skip-publish --config .goreleaser-linux-arm64.yml
+          args: release --skip=publish --config .goreleaser-linux-arm64.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -108,12 +108,12 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.21.0'
+          go-version: '>=1.21.3'
           cache: true
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - run: npm install
         working-directory: ui
@@ -127,7 +127,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --skip-publish --config .goreleaser-linux-armhf.yml
+          args: release --skip=publish --config .goreleaser-linux-armhf.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -157,12 +157,12 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.21.0'
+          go-version: '>=1.21.3'
           cache: true
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - run: npm install
         working-directory: ui
@@ -176,7 +176,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --skip-publish --config .goreleaser-darwin.yml
+          args: release --skip=publish --config .goreleaser-darwin.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
@@ -201,12 +201,12 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.21.0'
+          go-version: '>=1.21.3'
           cache: true
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - run: npm install
         working-directory: ui
@@ -220,7 +220,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --skip-publish --config .goreleaser-windows.yml
+          args: release --skip=publish --config .goreleaser-windows.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -10,7 +10,7 @@ builds:
     goarch:
       - amd64
     hooks:
-      post: gon build/gon-amd64.hcl
+      post: gon -log-level=info build/gon-amd64.hcl
 
   - id: zrok-arm64
     main: ./cmd/zrok
@@ -23,4 +23,4 @@ builds:
     goarch:
       - arm64
     hooks:
-      post: gon build/gon-arm64.hcl
+      post: gon -log-level=info build/gon-arm64.hcl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 FEATURE: The `sdk` package now includes a `sdk.Overview` function, which returns a complete description of the account attached to the enabled environment. Useful for inventorying the deployed shares and environments (https://github.com/openziti/zrok/issues/407)
 
+CHANGE: The `zrok access public` frontend configuration format has changed and now requires that the configuration document include a `v: 2` declaration. This frontend configuration format is now versioned and when the code updates the configuration structure, you will receive an error message at startup, provoking you to look into updating your configuration (https://github.com/openziti/zrok/issues/406)
+
 CHANGE: The title color of the header was changed from white to flourescent green, to better match the overall branding
 
 CHANGE: Tweaks to build and release process for logging and deprecations. Pin golang version at 1.21.3+ and node version at 18.x across all platforms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGE: The title color of the header was changed from white to flourescent gree
 
 CHANGE: Tweaks to build and release process for logging and deprecations. Pin golang version at 1.21.3+ and node version at 18.x across all platforms
 
+CHANGE: Improvements to email invitation sent in response to `zrok invite` to correct broken links, some minor HTML issues and improve overall deliverability (https://github.com/openziti/zrok/issues/405)
+
 # v0.4.7
 
 FEATURE: OAuth authentication with the ability to restrict authenticated users to specified domains for `zrok share public`. Supports both Google and GitHub authentication in this version. More authentication providers, and extensibility to come in future `zrok` releases. See the OAuth configuration guide at `docs/guides/self-hosting/oauth/configuring-oauth.md` for details (https://github.com/openziti/zrok/issues/45, https://github.com/openziti/zrok/issues/404)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 CHANGE: The title color of the header was changed from white to flourescent green, to better match the overall branding
 
+CHANGE: Tweaks to build and release process for logging and deprecations. Pin golang version at 1.21.3+ and node version at 18.x across all platforms
+
 # v0.4.7
 
 FEATURE: OAuth authentication with the ability to restrict authenticated users to specified domains for `zrok share public`. Supports both Google and GitHub authentication in this version. More authentication providers, and extensibility to come in future `zrok` releases. See the OAuth configuration guide at `docs/guides/self-hosting/oauth/configuring-oauth.md` for details (https://github.com/openziti/zrok/issues/45, https://github.com/openziti/zrok/issues/404)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.8
+
+CHANGE: The title color of the header was changed from white to flourescent green, to better match the overall branding
+
 # v0.4.7
 
 FEATURE: OAuth authentication with the ability to restrict authenticated users to specified domains for `zrok share public`. Supports both Google and GitHub authentication in this version. More authentication providers, and extensibility to come in future `zrok` releases. See the OAuth configuration guide at `docs/guides/self-hosting/oauth/configuring-oauth.md` for details (https://github.com/openziti/zrok/issues/45, https://github.com/openziti/zrok/issues/404)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v0.4.8
 
+FEATURE: The `sdk` package now includes a `sdk.Overview` function, which returns a complete description of the account attached to the enabled environment. Useful for inventorying the deployed shares and environments (https://github.com/openziti/zrok/issues/407)
+
 CHANGE: The title color of the header was changed from white to flourescent green, to better match the overall branding
 
 CHANGE: Tweaks to build and release process for logging and deprecations. Pin golang version at 1.21.3+ and node version at 18.x across all platforms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGE: Tweaks to build and release process for logging and deprecations. Pin go
 
 CHANGE: Improvements to email invitation sent in response to `zrok invite` to correct broken links, some minor HTML issues and improve overall deliverability (https://github.com/openziti/zrok/issues/405)
 
+CHANGE: Added warning message after `zrok invite` submit directing the user to check their "spam" folder if they do not receive the invite message.
+
 # v0.4.7
 
 FEATURE: OAuth authentication with the ability to restrict authenticated users to specified domains for `zrok share public`. Supports both Google and GitHub authentication in this version. More authentication providers, and extensibility to come in future `zrok` releases. See the OAuth configuration guide at `docs/guides/self-hosting/oauth/configuring-oauth.md` for details (https://github.com/openziti/zrok/issues/45, https://github.com/openziti/zrok/issues/404)

--- a/cmd/zrok/invite.go
+++ b/cmd/zrok/invite.go
@@ -89,7 +89,8 @@ func (cmd *inviteCommand) run(_ *cobra.Command, _ []string) {
 			tui.Error("error creating invitation", err)
 		}
 
-		fmt.Printf("invitation sent to '%v'!\n", email)
+		fmt.Printf("invitation sent to '%v'!\n\n", email)
+		fmt.Printf(fmt.Sprintf("%v\n\n", tui.Attention.Render("*** be sure to check your SPAM folder if you do not receive the invitation email!")))
 	}
 }
 

--- a/cmd/zrok/overview.go
+++ b/cmd/zrok/overview.go
@@ -3,10 +3,9 @@ package main
 import (
 	"fmt"
 	"github.com/openziti/zrok/environment"
+	"github.com/openziti/zrok/sdk"
 	"github.com/openziti/zrok/tui"
 	"github.com/spf13/cobra"
-	"io"
-	"net/http"
 )
 
 func init() {
@@ -41,32 +40,13 @@ func (cmd *overviewCommand) run(_ *cobra.Command, _ []string) {
 		tui.Error("unable to load environment; did you 'zrok enable'?", nil)
 	}
 
-	client := &http.Client{}
-	apiEndpoint, _ := root.ApiEndpoint()
-	req, err := http.NewRequest("GET", fmt.Sprintf("%v/api/v1/overview", apiEndpoint), nil)
+	json, err := sdk.Overview(root)
 	if err != nil {
 		if !panicInstead {
-			tui.Error("error accessing overview", err)
-		}
-		panic(err)
-	}
-	req.Header.Add("X-TOKEN", root.Environment().Token)
-	resp, err := client.Do(req)
-	if err != nil {
-		if !panicInstead {
-			tui.Error("error requesting overview", err)
+			tui.Error("error loading zrokdir", err)
 		}
 		panic(err)
 	}
 
-	json, err := io.ReadAll(resp.Body)
-	if err != nil {
-		if !panicInstead {
-			tui.Error("error reading body", err)
-		}
-		panic(err)
-	}
-	_ = resp.Body.Close()
-
-	fmt.Println(string(json))
+	fmt.Println(json)
 }

--- a/controller/emailUi/verify.gohtml
+++ b/controller/emailUi/verify.gohtml
@@ -7,37 +7,29 @@
     <title>Welcome to zrok!</title>
     <meta name="description" content="Please click to create your zrok account.">
     <meta name="viewport" content="width=device-width">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap" rel="stylesheet">
     <style>
         body {
             margin: 0;
-            padding: 25;
+            padding: 25px;
             font-family: 'JetBrains Mono', 'Courier New', monospace;
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
             color: #ffffff;
             background-color: #3b2693;
-
         }
 
         a:link {
-            color: #00d7e4;
+            color: white;
         }
 
         a:visited {
-            color: #00d7e4;
+            color: white;
         }
 
         a:hover,
         a:active {
             color: #ff0100;
-        }
-
-        .claim {
-            font-size: 2em;
-            margin: 0.5em 0 1em 0;
         }
 
         .container {
@@ -46,8 +38,6 @@
             max-width: 100%;
             text-align: center;
         }
-
-
 
         .btn {
             display: inline-block;
@@ -132,23 +122,23 @@
 
 <div class="container">
     <div class="banner" style="margin: auto;">
-        <img src="https://zrok.io/wp-content/uploads/2023/01/welcome.jpg" width="363px" height="500px" style="padding-bottom: 10px;"/>
+        <img src="https://zrok.io/wp-content/uploads/2023/01/welcome.jpg" width="363px" height="500px" style="padding-bottom: 10px;" alt="welcome to zrok"/>
     </div>
     <div class="cta" style="text-align: center;">
-        <p style="text-align: center;">Please click the button below to create your zrok account for {{ .EmailAddress }}.</p>
+        <p style="text-align: center; color: white;">Please click the button below to create your zrok account for {{ .EmailAddress }}.</p>
         <a class="btn btn-primary" href="{{ .VerifyUrl }}" style="color: #ffffff;">Create Account</a>
         <a class="btn btn-secondary" href="https://docs.zrok.io/" style="color: #ffffff">Documentation</a>
     </div>
 
     <table border="0" cellpadding="0" cellspacing="0" align="center" class="about">
         <tr>
-            <td><a href="https://github.com/openziti/zrok" target="_blank">github.com/openziti/zrok</a></td>
+            <td><a href="https://github.com/openziti/zrok" target="_blank" style="color: white;">github.com/openziti/zrok</a></td>
         </tr>
         <tr>
             <td>{{ .Version }}</td>
         </tr>
     </table>
-    <p style="text-align: center;"></a>Copyright © 2023 <a href="http://www.netfoundry.io" target="_blank" style="color: #00d7e4;">NetFoundry, Inc.</a></p>
+    <p style="text-align: center;">Copyright © 2023 <a href="http://www.netfoundry.io" target="_blank" style="color: white;">NetFoundry, Inc.</a></p>
 </div>
 </body>
 

--- a/controller/verifyEmail.go
+++ b/controller/verifyEmail.go
@@ -47,6 +47,7 @@ func sendVerificationEmail(emailAddress, token string) error {
 	msg.SetImportance(mail.ImportanceHigh)
 	msg.SetBodyString(mail.TypeTextPlain, plainBody)
 	msg.SetBodyString(mail.TypeTextHTML, htmlBody)
+	msg.SetHeader("List-Unsubscribe", "<mailto: invite@zrok.io?subject=unsubscribe>")
 
 	client, err := mail.NewClient(cfg.Email.Host,
 		mail.WithPort(cfg.Email.Port),

--- a/endpoints/publicProxy/config.go
+++ b/endpoints/publicProxy/config.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
+const V = 2
+
 type Config struct {
+	V         int
 	Identity  string
 	Address   string
 	HostMatch string
@@ -50,6 +53,9 @@ func DefaultConfig() *Config {
 func (c *Config) Load(path string) error {
 	if err := cf.BindYaml(c, path, cf.DefaultOptions()); err != nil {
 		return errors.Wrapf(err, "error loading frontend config '%v'", path)
+	}
+	if c.V != V {
+		return errors.Errorf("invalid configuration version '%d'; expected '%d'", c.V, V)
 	}
 	return nil
 }

--- a/etc/ctrl.yml
+++ b/etc/ctrl.yml
@@ -7,7 +7,7 @@
 
 # The `v` field determines the configuration version. When software is released that changes the structure of the
 # configuration, the software will expect this field to be incremented. This protects you against invalid configuration
-# versions.
+# versions and will refer to you to the documentation when the configuration structure changes.
 #
 v: 3
 

--- a/etc/frontend.yml
+++ b/etc/frontend.yml
@@ -7,10 +7,25 @@
 # The OAuth configuration is used when enabling OAuth authentication with your public frontend.
 #
 #oauth:
+#  # `redirect_host` and `redirect_port` should correspond with the DNS hostname and URL representing
+#  # the OAuth frontend you'll use with your installation.
+#  #
 #  redirect_host: oauth.zrok.io
 #  redirect_port: 28080
+#
+#  # `redirect_http_only` will generate an HTTP URI for your OAuth frontend, rather than HTTPS. This
+#  # should only be set to `true` in development environments.
+#  #
 #  redirect_http_only: false
+#
+#  # `hash_key` is a unique key for your installation that is used to secure authentication payloads
+#  # with OAuth providers.
+#  #
 #  hash_key: "<yourRandomHashKey>"
+#
+#  # `providers` contains an array of provider details enabled in your installation. Currently only
+#  # `google` and `github` are supported. Your configuration can include `google`, `github`, or both.
+#  #
 #  providers:
 #    - name: google
 #      client_id: <client-id>

--- a/etc/frontend.yml
+++ b/etc/frontend.yml
@@ -1,3 +1,9 @@
+# The `v` field determines the configuration version. When software is released that changes the structure of the
+# configuration, the software will expect this field to be incremented. This protects you against invalid configuration
+# versions and will refer to you to the documentation when the configuration structure changes.
+#
+v: 2
+
 # Setting the `host_match` setting will cause a `zrok access public` to ignore `Host` headers that do not contain the
 # configured string. This will allow you to let a load balancer access the frontend by IP address for health check
 # purposes, and will allow `Host` headers that match the configured DNS name to be routed through `zrok`.

--- a/sdk/overview.go
+++ b/sdk/overview.go
@@ -1,0 +1,35 @@
+package sdk
+
+import (
+	"errors"
+	"fmt"
+	"github.com/openziti/zrok/environment/env_core"
+	"io"
+	"net/http"
+)
+
+func Overview(root env_core.Root) (string, error) {
+	if !root.IsEnabled() {
+		return "", errors.New("environment is not enabled; enable with 'zrok enable' first!")
+	}
+
+	client := &http.Client{}
+	apiEndpoint, _ := root.ApiEndpoint()
+	req, err := http.NewRequest("GET", fmt.Sprintf("%v/api/v1/overview", apiEndpoint), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("X-TOKEN", root.Environment().Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	json, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	_ = resp.Body.Close()
+
+	return string(json), nil
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -21,6 +21,7 @@ code, pre {
     margin-left: 0.53em;
     vertical-align: center;
     line-height: 1.7;
+    color: #9BF316;
 }
 
 .visualizer-container {


### PR DESCRIPTION
FEATURE: The `sdk` package now includes a `sdk.Overview` function, which returns a complete description of the account attached to the enabled environment. Useful for inventorying the deployed shares and environments (https://github.com/openziti/zrok/issues/407)

CHANGE: The `zrok access public` frontend configuration format has changed and now requires that the configuration document include a `v: 2` declaration. This frontend configuration format is now versioned and when the code updates the configuration structure, you will receive an error message at startup, provoking you to look into updating your configuration (https://github.com/openziti/zrok/issues/406)

CHANGE: The title color of the header was changed from white to flourescent green, to better match the overall branding

CHANGE: Tweaks to build and release process for logging and deprecations. Pin golang version at 1.21.3+ and node version at 18.x across all platforms

CHANGE: Improvements to email invitation sent in response to `zrok invite` to correct broken links, some minor HTML issues and improve overall deliverability (https://github.com/openziti/zrok/issues/405)

CHANGE: Added warning message after `zrok invite` submit directing the user to check their "spam" folder if they do not receive the invite message.

