### PR TITLE
Improved OAuth Frontend Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.10
+
+CHANGE: The public frontend configuration has been bumped from `v: 2` to `v: 3`. The `redirect_host`, `redirect_port` and `redirect_http_only` parameters have been removed. These three configuration options have been replaced with `bind_address`, `redirect_url` and `cookie_domain`. See the OAuth configuration guide at `docs/guides/self-hosting/oauth/configuring-oauth.md` for more details (https://github.com/openziti/zrok/issues/411)
+
 # v0.4.9
 
 FIX: Remove extraneous share token prepended to OAuth frontend redirect.

--- a/docs/guides/self-hosting/oauth/configuring-oauth.md
+++ b/docs/guides/self-hosting/oauth/configuring-oauth.md
@@ -90,23 +90,25 @@ The public frontend configuration includes a new `oauth` section:
 
 ```yaml
 oauth:
-  redirect_host: oauth.zrok.io
-  redirect_port: 28080
-  redirect_http_only: false
-  hash_key: "<yourRandomHashKey>"
+  bind_address:                   0.0.0.0:8181
+  redirect_url:                   https://oauth.zrok.io
+  cookie_domain:                  zrok.io
+  hash_key:                       "the quick brown fox jumped over the lazy dog"
   providers:
-    - name: google
-      client_id: <client-id>
-      client_secret: <client-secret>
-    - name: github
-      client_id: <client-id>
-      client_secret: <client-secret>
+    - name:                       google
+      client_id:                  "<client id from google>"
+      client_secret:              "<client secret from google>"
+    - name:                       github
+      client_id:                  "<client id from github>"
+      client_secret:              "<client secret from github>"
       
 ```
 
-The `redirect_host` and `redirect_port` value should correspond with the DNS hostname and port configured as your OAuth frontend.
+The `bind_address` parameter determines where the OAuth frontend will bind. Should be in `ip:port` format.
 
-The `redirect_http_only` is useful in development environments where your OAuth frontend is not running behind an HTTPS reverse proxy. Should not be enabled in production environments!
+The `redirect_url` parameter determines the base URL where OAuth frontend requests will be redirected.
+
+`cookie_domain` is the domain where authentication cookies should be stored.
 
 `hash_key` is a unique string for your installation that is used to secure the authentication payloads for your public frontend.
 

--- a/endpoints/publicProxy/config.go
+++ b/endpoints/publicProxy/config.go
@@ -2,15 +2,13 @@ package publicProxy
 
 import (
 	"context"
-	"fmt"
 	"github.com/michaelquigley/cf"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	zhttp "github.com/zitadel/oidc/v2/pkg/http"
-	"strings"
 )
 
-const V = 2
+const V = 3
 
 type Config struct {
 	V         int
@@ -21,11 +19,11 @@ type Config struct {
 }
 
 type OauthConfig struct {
-	RedirectHost     string
-	RedirectPort     int
-	RedirectHttpOnly bool
-	HashKey          string `cf:"+secret"`
-	Providers        []*OauthProviderConfig
+	BindAddress  string
+	RedirectUrl  string
+	CookieDomain string
+	HashKey      string `cf:"+secret"`
+	Providers    []*OauthProviderConfig
 }
 
 func (oc *OauthConfig) GetProvider(name string) *OauthProviderConfig {
@@ -71,6 +69,6 @@ func configureOauthHandlers(ctx context.Context, cfg *Config, tls bool) error {
 	if err := configureGithubOauth(cfg.Oauth, tls); err != nil {
 		return err
 	}
-	zhttp.StartServer(ctx, fmt.Sprintf("%s:%d", strings.Split(cfg.Address, ":")[0], cfg.Oauth.RedirectPort))
+	zhttp.StartServer(ctx, cfg.Oauth.BindAddress)
 	return nil
 }

--- a/etc/frontend.yml
+++ b/etc/frontend.yml
@@ -2,7 +2,7 @@
 # configuration, the software will expect this field to be incremented. This protects you against invalid configuration
 # versions and will refer to you to the documentation when the configuration structure changes.
 #
-v: 2
+v: 3
 
 # Setting the `host_match` setting will cause a `zrok access public` to ignore `Host` headers that do not contain the
 # configured string. This will allow you to let a load balancer access the frontend by IP address for health check
@@ -13,16 +13,19 @@ v: 2
 # The OAuth configuration is used when enabling OAuth authentication with your public frontend.
 #
 #oauth:
-#  # `redirect_host` and `redirect_port` should correspond with the DNS hostname and URL representing
-#  # the OAuth frontend you'll use with your installation.
+#  # `bind_address` is the <address:port> of the interface where the OAuth frontend listener should
+#  # bind
 #  #
-#  redirect_host: oauth.zrok.io
-#  redirect_port: 28080
+#  bind_address: 127.0.0.1:8181
 #
-#  # `redirect_http_only` will generate an HTTP URI for your OAuth frontend, rather than HTTPS. This
-#  # should only be set to `true` in development environments.
+#  # `redirect_url` is the <scheme://address[:port]> of the URL where OAuth requests should be directed.
 #  #
-#  redirect_http_only: false
+#  redirect_url: https://oauth.zrok.io
+#
+#  # `cookie_domain` is the domain where the authentication cookies should be applied. Should likely match
+#  # the `host_match` specified above.
+#  #
+#  cookie_domain: zrok.io
 #
 #  # `hash_key` is a unique key for your installation that is used to secure authentication payloads
 #  # with OAuth providers.


### PR DESCRIPTION
CHANGE: The public frontend configuration has been bumped from `v: 2` to `v: 3`. The `redirect_host`, `redirect_port` and `redirect_http_only` parameters have been removed. These three configuration options have been replaced with `bind_address`, `redirect_url` and `cookie_domain`. See the OAuth configuration guide at `docs/guides/self-hosting/oauth/configuring-oauth.md` for more details (https://github.com/openziti/zrok/issues/411)
