### PR TITLE
Reserved OAuth Shares; JSON Output for 'zrok reserve'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.11
+
+FIX: Include `--oauth-provider` and associated flags for the `zrok reserve` command, allowing reserved shares to specify OAuth authentication (https://github.com/openziti/zrok/issues/421)
+
 # v0.4.10
 
 CHANGE: The public frontend configuration has been bumped from `v: 2` to `v: 3`. The `redirect_host`, `redirect_port` and `redirect_http_only` parameters have been removed. These three configuration options have been replaced with `bind_address`, `redirect_url` and `cookie_domain`. See the OAuth configuration guide at `docs/guides/self-hosting/oauth/configuring-oauth.md` for more details (https://github.com/openziti/zrok/issues/411)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v0.4.11
 
+FEATURE: The `zrok reserve` command now incorporates the `--json-output|-j` flag, which outputs the reservation details as JSON, rather than as human-consumable log messages. Other commands will produce similar output in the future (https://github.com/openziti/zrok/issues/422)
+
 FIX: Include `--oauth-provider` and associated flags for the `zrok reserve` command, allowing reserved shares to specify OAuth authentication (https://github.com/openziti/zrok/issues/421)
 
 # v0.4.10

--- a/cmd/zrok/reserve.go
+++ b/cmd/zrok/reserve.go
@@ -100,6 +100,9 @@ func (cmd *reserveCommand) run(_ *cobra.Command, args []string) {
 		req.Frontends = cmd.frontendSelection
 	}
 	if cmd.oauthProvider != "" {
+		if shareMode != sdk.PublicShareMode {
+			tui.Error("--oauth-provider only supported for public shares", nil)
+		}
 		req.OauthProvider = cmd.oauthProvider
 		req.OauthEmailDomains = cmd.oauthEmailDomains
 		req.OauthAuthorizationCheckInterval = cmd.oauthCheckInterval

--- a/sdk/model.go
+++ b/sdk/model.go
@@ -31,8 +31,8 @@ type ShareRequest struct {
 }
 
 type Share struct {
-	Token             string
-	FrontendEndpoints []string
+	Token             string   `json:"token"`
+	FrontendEndpoints []string `json:"frontend_endpoints"`
 }
 
 type AccessRequest struct {


### PR DESCRIPTION
Include support for creating reserved shares that use OAuth authentication (#421)

Include a flag that causes `zrok reserve` to emit the share reservation details as a JSON object (#422)