### PR TITLE
workflows(homebrew): fix url format issue

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -16,6 +16,6 @@ jobs:
         if: "!contains(github.ref, '-')"
         with:
           formula-name: zrok
-          download-url: https://github.com/openziti/zrok/archive/${{ steps.extract-version.outputs.tag-name }}.tar.gz
+          download-url: https://github.com/openziti/zrok/archive/refs/tags/${{ steps.extract-version.outputs.tag-name }}.tar.gz
         env:
           COMMITTER_TOKEN: ${{ secrets.BREW_COMMITTER_TOKEN }}

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -12,7 +12,7 @@ jobs:
         id: extract-version
         run: |
           printf "::set-output name=%s::%s\n" tag-name "${GITHUB_REF#refs/tags/}"
-      - uses: mislav/bump-homebrew-formula-action@v2
+      - uses: mislav/bump-homebrew-formula-action@v3.1
         if: "!contains(github.ref, '-')"
         with:
           formula-name: zrok


### PR DESCRIPTION
Looks like the change in v2.4 release (https://github.com/mislav/bump-homebrew-formula-action/pull/53) did not get picked up with v2 tag, thus bumping to the latest, v3.1 (also bump the runtime to node20)

relates to https://github.com/Homebrew/homebrew-core/pull/152376