### PR TITLE
frontdoor option - exit after reserve

### DIFF
--- a/nfpm/zrok-share.bash
+++ b/nfpm/zrok-share.bash
@@ -25,6 +25,10 @@ fi
 # set HOME to the first colon-sep dir in STATE_DIRECTORY inherited from systemd (/var/lib/zrok-share) or docker (/mnt)
 export HOME="${STATE_DIRECTORY%:*}"
 
+: "${ZROK_SHARE_RESERVED:=true}"
+
+echo "DEBUG: ZROK_SHARE_RESERVED=${ZROK_SHARE_RESERVED}"
+
 if (( $# )); then
   if [[ -s "$1" ]]; then
     echo "INFO: reading share configuration from $1"
@@ -60,9 +64,14 @@ elif [[ -s ~/.zrok/reserved.json ]]; then
     exit 1
   else
     echo "INFO: zrok backend is already reserved: ${ZROK_RESERVED_TOKEN}"
-    ZITI_CMD="${ZROK_RESERVED_TOKEN} ${ZROK_TARGET}"
-    ZITI_CMD+=" ${ZROK_VERBOSE:-} ${ZROK_INSECURE:-}"
-    share_reserved ${ZITI_CMD}
+    ZROK_CMD="${ZROK_RESERVED_TOKEN} ${ZROK_TARGET}"
+    ZROK_CMD+=" ${ZROK_VERBOSE:-} ${ZROK_INSECURE:-}"
+    if [[ "${ZROK_SHARE_RESERVED}" == true ]]; then
+      share_reserved ${ZROK_CMD}
+    else
+      echo "INFO: finished reserving zrok backend, continuing without sharing"
+      exit 0
+    fi
   fi
 else
   ZROK_CMD="reserve public --json-output ${ZROK_VERBOSE:-}"
@@ -154,6 +163,11 @@ else
     fi
     ZROK_CMD="${ZROK_RESERVED_TOKEN} ${ZROK_TARGET}"
     ZROK_CMD+=" ${ZROK_VERBOSE:-} ${ZROK_INSECURE:-}"
-    share_reserved ${ZROK_CMD}
+    if [[ "${ZROK_SHARE_RESERVED}" == true ]]; then
+      share_reserved ${ZROK_CMD}
+    else
+      echo "INFO: finished reserving zrok backend, continuing without sharing"
+      exit 0
+    fi
   fi
 fi


### PR DESCRIPTION
This supports using the SDKs to host instead of a proxy.

The change in behavior is the same for the Linux service and Docker reserved public share because they both leverage zrok-share.bash to reserve unless reserved and share unless using the SDK.

The idea is that an SDK-hosted share that's using frontdoor tooling to orchestrate the zrok env and share will set ZROK_SHARE_RESERVED="false" to tell zrok-share.bash to exit 0 after it finishes reserving the share.

Example of [a Docker project override](https://github.com/qrkourier/zrok_django_radial_calendar/blob/main/compose.override.yml#L10) (`compose.override.yml`) that sets this var, overriding the unmodified base project file from the zrok repo, so the SDK app can use the same frontdoor Compose project.

