### PR TITLE
check local storage for user info before redirecting to the login page

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -17,6 +17,8 @@ const App = () => {
                 console.log("reloaded user", localUser);
             }
         }
+
+        checkUserData()
       
         document.addEventListener('storage', checkUserData)
       


### PR DESCRIPTION
currently zrok redirects the user to the login page even if the user has already logged in and its info is store in the local storage

https://github.com/openziti/zrok/assets/65053572/1f4f3f28-2cba-4282-9f99-b83e99487d2f


https://github.com/openziti/zrok/assets/65053572/536c3761-dd52-4c04-8fdb-8c6ee2422ab8

 