### PR TITLE
Add Permission Mode and Access Grants to Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.4.27
+
+FIX: Also update the Python SDK to include the permission mode and access grants fields on the `ShareRequest` (https://github.com/openziti/zrok/issues/432)
+
 ## v0.4.26
 
 FEATURE: New _permission modes_ available for shares. _Open permission mode_ retains the behavior of previous zrok releases and is the default setting. _Closed permission mode_ (`--closed`) only allows a share to be accessed (`zrok access`) by users who have been granted access with the `--access-grant` flag. See the documentation at (https://docs.zrok.io/docs/guides/permission-modes/) (https://github.com/openziti/zrok/issues/432)

--- a/sdk/python/sdk/zrok/zrok/model.py
+++ b/sdk/python/sdk/zrok/zrok/model.py
@@ -34,6 +34,7 @@ class ShareRequest:
     PermissionMode: PermissionMode = OPEN_PERMISSION_MODE
     AccessGrants: list[str] = field(default_factory=list[str])
 
+
 @dataclass
 class Share:
     Token: str

--- a/sdk/python/sdk/zrok/zrok/model.py
+++ b/sdk/python/sdk/zrok/zrok/model.py
@@ -13,6 +13,11 @@ ShareMode = str
 PRIVATE_SHARE_MODE: ShareMode = "private"
 PUBLIC_SHARE_MODE: ShareMode = "public"
 
+PermissionMode = str
+
+OPEN_PERMISSION_MODE: PermissionMode = "open"
+CLOSED_PERMISSION_MODE: PermissionMode = "closed"
+
 
 @dataclass
 class ShareRequest:
@@ -26,7 +31,8 @@ class ShareRequest:
     OauthAuthorizationCheckInterval: str = ""
     Reserved: bool = False
     UniqueName: str = ""
-
+    PermissionMode: PermissionMode = OPEN_PERMISSION_MODE
+    AccessGrants: list[str] = field(default_factory=list[str])
 
 @dataclass
 class Share:

--- a/sdk/python/sdk/zrok/zrok/share.py
+++ b/sdk/python/sdk/zrok/zrok/share.py
@@ -67,7 +67,9 @@ def __newPrivateShare(root: Root, request: model.ShareRequest) -> ShareRequest:
                         share_mode=request.ShareMode,
                         backend_mode=request.BackendMode,
                         backend_proxy_endpoint=request.Target,
-                        auth_scheme=model.AUTH_SCHEME_NONE
+                        auth_scheme=model.AUTH_SCHEME_NONE,
+                        permission_mode=request.permission_mode,
+                        access_grants=request.access_grants
                         )
 
 
@@ -79,7 +81,9 @@ def __newPublicShare(root: Root, request: model.ShareRequest) -> ShareRequest:
                        backend_proxy_endpoint=request.Target,
                        auth_scheme=model.AUTH_SCHEME_NONE,
                        oauth_email_domains=request.OauthEmailAddressPatterns,
-                       oauth_authorization_check_interval=request.OauthAuthorizationCheckInterval
+                       oauth_authorization_check_interval=request.OauthAuthorizationCheckInterval,
+                       permission_mode=request.permission_mode,
+                       access_grants=request.access_grants
                        )
     if request.OauthProvider != "":
         ret.oauth_provider = request.OauthProvider


### PR DESCRIPTION
Fix missing permission mode and access grants from `ShareRequest` in Python SDK implementation.