### PR TITLE
Update macos.mdx

### DIFF
--- a/docs/guides/install/macos.mdx
+++ b/docs/guides/install/macos.mdx
@@ -23,7 +23,7 @@ Download the binary distribution for your macOS architecture. For Intel Macs use
 1. Unarchive the distribution in a temporary directory.
 
     ```text
-    mkdir /tmp/zrok && tar -xf ./zrok*darwin*.tar.gz -C /tmp/zrok
+    cd ~/Downloads && mkdir -p /tmp/zrok && tar -xf ./zrok*darwin*.tar.gz -C /tmp/zrok
     ```
 
 1. Install the `zrok` executable.


### PR DESCRIPTION
Default download of binary is in downloads, if running script and the /tmp/zrok directory already exists, an error is thrown -p /tmp/zrok will work even if the directory already exists without throwing an error.