### PR TITLE
Add private share support to zrok-share (frontdoor)

### DIFF
--- a/nfpm/zrok-share.bash
+++ b/nfpm/zrok-share.bash
@@ -54,8 +54,8 @@ fi
   exit 1
 }
 
-# default mode is 'temp-public' (unreserved), override modes are temp-private, reserver-public, reserved-private.
-: "${ZROK_FRONTEND_MODE:-temp-public}"
+# default mode is 'reserved-public', override modes are reserved-private, temp-public, temp-private.
+: "${ZROK_FRONTEND_MODE:-reserved-public}"
 if [[ "${ZROK_FRONTEND_MODE:-}" == temp-public ]]; then
   ZROK_CMD="share public --headless ${ZROK_VERBOSE:-}"
 elif [[ "${ZROK_FRONTEND_MODE:-}" == temp-private ]]; then

--- a/nfpm/zrok-share.env
+++ b/nfpm/zrok-share.env
@@ -86,3 +86,7 @@ ZROK_SHARE_OPTS=""
 # set if self-hosting zrok and not using only the default frontend name 'public'; must be a space-separated list
 # WARNING: changes take effect the next time the frontend URL is reserved
 #ZROK_FRONTENDS="public"
+
+# you MAY set to change the frontend mode: temp-public (default), temp-private, reserved-public, reserved-private
+# WARNING: changes take effect the next time the frontend URL is reserved
+#ZROK_FRONTEND_MODE="temp-public"

--- a/nfpm/zrok-share.env
+++ b/nfpm/zrok-share.env
@@ -87,6 +87,6 @@ ZROK_SHARE_OPTS=""
 # WARNING: changes take effect the next time the frontend URL is reserved
 #ZROK_FRONTENDS="public"
 
-# you MAY set to change the frontend mode: temp-public (default), temp-private, reserved-public, reserved-private
+# you MAY set to change the frontend mode: reserved-public (default), reserved-private, temp-public, temp-private 
 # WARNING: changes take effect the next time the frontend URL is reserved
-#ZROK_FRONTEND_MODE="temp-public"
+#ZROK_FRONTEND_MODE="reserved-public"


### PR DESCRIPTION
nfpm: Modified zrok-share to cater for private temporary and reserved shares, controlled by ZROK_FRONTEND_MODE; Modified env file with additional variable ZROK_FRONTEND_MODE;

See OpenZiti Discourse discussion [here](https://openziti.discourse.group/t/cant-forward-to-a-dedicated-custom-domain-name/2541/22).