### PR TITLE
Fix for zrok_interstitial Cookie on Chrome-based Browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.4.37
 
+FIX: Fix for setting the `zrok_interstitial` cookie on Chrome-based browsers.
+
 FIX: When an error occurs connecting to the proxied endpoint, the `proxy` backend should return HTTP status `502` (https://github.com/openziti/zrok/issues/703)
 
 ## v0.4.36

--- a/endpoints/publicProxy/interstitialUi/index.html
+++ b/endpoints/publicProxy/interstitialUi/index.html
@@ -108,8 +108,10 @@
 <body>
 	<script>
 		function onClick() {
-			let e=new Date; e.setTime(e.getTime()+6048e5);
-			document.cookie = 'zrok_interstitial = 1; expires=${e}; path=/; SameSite=None';
+			const d = new Date();
+			d.setTime(d.getTime() + (7 * 24 * 60 * 60 * 1000));
+			let expires = "expires=" + d.toUTCString();
+			document.cookie = "zrok_interstitial=1;" + expires + ";path=/;SameSite=None';domain=" + window.location.hostname;
 			window.location.reload();
 		}
 	</script>


### PR DESCRIPTION
Add `domain=` to cookie details.