### PR TITLE
Respect 'deleted' Flag in Skip Interstitial Grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.4.37
 
+FIX: Fix for `store.IsAccountGrantedSkipInterstitial` to respect the `deleted` flag.
+
 FIX: When an error occurs connecting to the proxied endpoint, the `proxy` backend should return HTTP status `502` (https://github.com/openziti/zrok/issues/703)
 
 ## v0.4.36

--- a/controller/store/skipInterstitialGrant.go
+++ b/controller/store/skipInterstitialGrant.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (str *Store) IsAccountGrantedSkipInterstitial(acctId int, trx *sqlx.Tx) (bool, error) {
-	stmt, err := trx.Prepare("select count(0) from skip_interstitial_grants where account_id = $1")
+	stmt, err := trx.Prepare("select count(0) from skip_interstitial_grants where account_id = $1 and not deleted")
 	if err != nil {
 		return false, errors.Wrap(err, "error preparing skip_interstitial_grants select statement")
 	}


### PR DESCRIPTION
Respect the deleted flag in the `skip_interstitial_grants` table.