### PR TITLE
organize self-service invitation doc

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -96,49 +96,6 @@ If [sharing privately](./concepts/sharing-private.md), only users with the share
   </div>
 </AssetsProvider>
 
-## Generating an Invitation
-
-:::note
-If not using `zrok.io` (zrok-as-a-service), you must configure the `zrok` command to use your instance. See the [instance configuration guide](/guides/self-hosting/instance-configuration.mdx) in the self-hosting section for details.
-:::
-
-Invite yourself to `zrok` by running the `zrok invite` command:
-
-```text
-zrok invite
-```
-
-```buttonless title="Output"
-enter and confirm your email address...
-
-> user@domain.com
-> user@domain.com
-
-[ Submit ]
-
-invitation sent to 'user@domain.com'!
-```
-
-The `zrok invite` command presents a small form that allows you to enter (and then confirm) your email address. Tabbing to the `[ Submit ]` button will send the request to your configured `zrok` service.
-
-Next, check the email where you sent the invite. You should receive a message asking you to click a link to create your `zrok` account. When you click that link, you will be brought to a web page that will allow you to set a password for your new account:
-
-![Enter a Password](images/zrok_verify.png)
-
-Enter a password and its confirmation, and click the `Register Account` button. You'll see the following:
-
-![Successful Registration](images/zrok_registration_success.png)
-
-For now, we'll ignore the "enable your shell for zrok" section. Just click the `zrok web portal` link:
-
-![Web Login](images/zrok_web_login.png)
-
-After clicking the `Log In` button, you'll be brought into the `zrok` _web console_:
-
-![Web Console; Empty](images/zrok_web_console_empty.png)
-
-Congratulations! Your `zrok` account is ready to go!
-
 ## Enabling Your zrok Environment
 
 A zrok environment usually refers to an enabled device where shares and accesses can be created, .e.g., `~/.zrok` on a Unix machine. It can be a specific user's environment or a system-wide agent's environment owned by the administrator.
@@ -371,7 +328,7 @@ Here's a quick review of the `zrok` mental model and the vocabulary.
 
 You create an _account_ with a `zrok` _instance_. Your account is identified by a username and a password, which you use to log into the _web console_. Your account also has a _secret token_, which you will use to authenticate from the `zrok` command-line to interact with the _instance_.
 
-You create a new _account_ with a `zrok` _instance_ through the `zrok invite` command.
+You create a new _account_ with NetFoundry's `zrok` _instance_ by subscribing in [myzrok.io](https://myzrok.io) or in a self-hosted `zrok` _instance_ by running [the `zrok invite` command](/guides/self-hosting/self-service-invite.mdx).
 
 ### Environment
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -9,24 +9,9 @@ import DownloadCard from '@site/src/components/download-card';
 import DownloadCardStyles from '@site/src/css/download-card.module.css';
 
 
-## Choose Your Path
+## Get an Account
 
 <Columns className='text--center getting-started-cards'> 
-  <Column style={{paddingBottom: 20}}>
-    <Card shadow='tl'>
-      <CardHeader>
-        <h3>Self-Hosted zrok</h3>
-      </CardHeader>
-      <CardBody>
-        Run a zrok instance on Linux, Docker, or Kubernetes.
-      </CardBody>
-      <CardFooter>
-        <a href="/docs/category/self-hosting/">
-        <button className='button button--secondary button--block'>Guides</button>
-        </a>
-      </CardFooter>
-    </Card>
-  </Column>
   <Column style={{paddingBottom: 20}}>
     <Card shadow='tl'>
       <CardHeader>
@@ -38,6 +23,21 @@ import DownloadCardStyles from '@site/src/css/download-card.module.css';
       <CardFooter>
         <a href="https://myzrok.io/">
         <button className='button button--secondary button--block'>Get an Account</button>
+        </a>
+      </CardFooter>
+    </Card>
+  </Column>
+  <Column style={{paddingBottom: 20}}>
+    <Card shadow='tl'>
+      <CardHeader>
+        <h3>Self-Hosted zrok</h3>
+      </CardHeader>
+      <CardBody>
+        Run a zrok instance on Linux, Docker, or Kubernetes.
+      </CardBody>
+      <CardFooter>
+        <a href="/docs/category/self-hosting/">
+        <button className='button button--secondary button--block'>Guides</button>
         </a>
       </CardFooter>
     </Card>
@@ -97,6 +97,8 @@ If [sharing privately](./concepts/sharing-private.md), only users with the share
 </AssetsProvider>
 
 ## Enabling Your zrok Environment
+
+After you have [an account](#get-an-account), you can enable your `zrok` environment.
 
 A zrok environment usually refers to an enabled device where shares and accesses can be created, .e.g., `~/.zrok` on a Unix machine. It can be a specific user's environment or a system-wide agent's environment owned by the administrator.
 

--- a/docs/guides/self-hosting/self-service-invite.mdx
+++ b/docs/guides/self-hosting/self-service-invite.mdx
@@ -1,0 +1,54 @@
+---
+title: Invitations
+---
+
+This is how to set up self-service invitations for your users to get an account on your self-hosted zrok instance.
+
+## Overview
+
+- You can create user accounts directly with the `zrok admin` CLI or API.
+- You can welcome users to invite themselves via email.
+- You can generate invitation tokens if you want to restrict self-service invitations.
+- To enable self-service invitations you must also configure the controller to send email.
+
+## The Self-Service User Experience
+
+This is what your users will do.
+
+```bash
+zrok invite
+```
+
+```buttonless title="Output"
+enter and confirm your email address...
+
+> user@domain.com
+> user@domain.com
+
+[ Submit ]
+
+invitation sent to 'user@domain.com'!
+```
+
+## How it Works
+
+The `zrok invite` command presents a small form that allows you to enter (and then confirm) your email address. Tabbing to the `[ Submit ]` button will start the invitation process.
+
+Next, check the email where you sent the invite. You should receive a message asking you to click a link to create your `zrok` account. When you click that link, you will be brought to a web page that will allow you to set a password for your new account.
+
+![Enter a Password](/zrok_verify.png)
+
+Enter a password and its confirmation, and click the `Register Account` button. You'll see the following:
+
+![Successful Registration](/zrok_registration_success.png)
+
+For now, we'll ignore the "enable your shell for zrok" section. Just click the `zrok web portal` link:
+
+![Web Login](/zrok_web_login.png)
+
+After clicking the `Log In` button, you'll be brought into the `zrok` _web console_:
+
+![Web Console; Empty](/zrok_web_console_empty.png)
+
+Congratulations! Your `zrok` account is ready to go!
+


### PR DESCRIPTION
Organize the invitation doc content to:

1. promote myzrok.io for NetFoundry instance users
2. minimize the getting started article
3. reduce confusion about how to create an account