### PR TITLE
Add ziti-quickstart to the depends_on fields of controller and frontend

### DIFF
--- a/docker/compose/zrok-instance/compose.yml
+++ b/docker/compose/zrok-instance/compose.yml
@@ -87,6 +87,8 @@ services:
     depends_on:
         zrok-permissions:
           condition: service_completed_successfully
+        ziti-quickstart:
+          condition: service_healthy
     build:
       context: .
       dockerfile: ./zrok-controller.Dockerfile
@@ -121,6 +123,8 @@ services:
     depends_on:
         zrok-permissions:
           condition: service_completed_successfully
+        ziti-quickstart:
+          condition: service_healthy
     build:
       context: .
       dockerfile: zrok-frontend.Dockerfile


### PR DESCRIPTION
- Adds `ziti-quickstart` to the `depends_on` fields of `ziti-controller` and `ziti-frontend` to avoid the issue where neither service recovers if the quickstart takes too long to initialize.
- I did test this with simply `service_started`, but it wasn't enough to make it work. Hopefully there aren't scenarios where `ziti-quickstart` is intended to only report as started instead of healthy.