### PR TITLE
Docker instance tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ FIX: Docker reserved private share startup error (https://github.com/openziti/zr
 FIX: Correct the download URL for the armv7 Linux release (https://github.com/openziti/zrok/issues/782)
 
 
+CHANGE: Let the zrok instance for Docker use port 80 as an edge listener instead of HTTP redirect (https://github.com/openziti/zrok/issues/793)
+
 ## v0.4.44
 
 FIX: Fix for goreleaser build action to align with changed ARM64 build path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 FIX: Docker share examples had incorrect default path for zrok environment mountpoint
 
+CHANGE: Use port 80 for the default Ziti API endpoint in the zrok Docker instance sample (https://github.com/openziti/zrok/issues/793).
+
+FIX: Clarify how to use DNS providers like Route53 with the zrok Docker instance sample.
+
 ## v0.4.45
 
-FEATURE: Minimal support for "organizations". Site admin API endpoints provided to create, list, and delete "organizations". Site admin API endpoints provided to add, list, and remove "organization members" (zrok accounts) with the ability to mark accounts as a "organization admin". API endpoints provided for organization admins to list the members of their organizations, and to also see the overview (environments, shares, and accesses) for any account in their organization. API endpoint for end users to see which organizations their account is a member of (https://github.com/openziti/zrok/issues/537) 
+FEATURE: Minimal support for "organizations". Site admin API endpoints provided to create, list, and delete "organizations". Site admin API endpoints provided to add, list, and remove "organization members" (zrok accounts) with the ability to mark accounts as a "organization admin". API endpoints provided for organization admins to list the members of their organizations, and to also see the overview (environments, shares, and accesses) for any account in their organization. API endpoint for end users to see which organizations their account is a member of (https://github.com/openziti/zrok/issues/537)
 
 CHANGE: briefly mention the backend modes that apply to public and private share concepts
 
@@ -19,9 +23,6 @@ FIX: reduce Docker image sizes (https://github.com/openziti/zrok/pull/783)
 FIX: Docker reserved private share startup error (https://github.com/openziti/zrok/pull/801)
 
 FIX: Correct the download URL for the armv7 Linux release (https://github.com/openziti/zrok/issues/782)
-
-
-CHANGE: Let the zrok instance for Docker use port 80 as an edge listener instead of HTTP redirect (https://github.com/openziti/zrok/issues/793)
 
 ## v0.4.44
 

--- a/docker/compose/zrok-instance/Caddyfile
+++ b/docker/compose/zrok-instance/Caddyfile
@@ -4,9 +4,9 @@
 	admin 0.0.0.0:2019
 }
 
-http:// {
-	redir https://{host}{uri} permanent
-}
+# http:// {
+# 	redir https://{host}{uri} permanent
+# }
 
 *.{$ZROK_DNS_ZONE} {
 	tls {
@@ -22,7 +22,7 @@ http:// {
 
 	# ziti administration console uses :443 for the benefit of a web UI cert and accesses the ziti edge-management API
 	@ziti host ziti.{$ZROK_DNS_ZONE}
-	reverse_proxy @ziti ziti-quickstart:{$ZITI_CTRL_ADVERTISED_PORT:1280} {
+	reverse_proxy @ziti ziti-quickstart:{$ZITI_CTRL_ADVERTISED_PORT:80} {
 		transport http {
 			tls_insecure_skip_verify
 		}

--- a/docker/compose/zrok-instance/README.md
+++ b/docker/compose/zrok-instance/README.md
@@ -65,6 +65,10 @@ ZROK_ADMIN_TOKEN=zroktoken
 
 ```bash title=".env options"
 # Caddy TLS option: rename compose.caddy.yml to compose.override.yml and set these vars; allow 80,443 in firewall
+
+#
+## set these in .env for providers other than Route53
+#
 # plugin name for your DNS provider
 CADDY_DNS_PLUGIN=cloudflare
 # API token from your DNS provider
@@ -72,22 +76,34 @@ CADDY_DNS_PLUGIN_TOKEN=abcd1234
 # use the staging API until you're sure everything is working to avoid hitting the rate limit
 CADDY_ACME_API=https://acme-staging-v02.api.letsencrypt.org/directory
 
-# no TLS option: publish the insecure ports to the internet and allow them in the firewall 
-ZROK_INSECURE_INTERFACE=0.0.0.0
+#
+## set these in .env for Route53
+#
+# AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+# AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+# AWS_REGION: ${AWS_REGION}
+# AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}  # if temporary credential, e.g., from STS
+
+#
+## if not using Caddy for TLS, uncomment to publish the insecure ports to the internet
+#
+#ZROK_INSECURE_INTERFACE=0.0.0.0
+
+# these insecure ports must be proxied with TLS for security
 ZROK_CTRL_PORT=18080
 ZROK_FRONTEND_PORT=8080
 ZROK_OAUTH_PORT=8081
 
-# ziti ports must be published to the internet and allowed by firewall
+# these secure ziti ports must be published to the internet
 ZITI_CTRL_ADVERTISED_PORT=80
 ZITI_ROUTER_PORT=3022
 
-# configure oauth for public shares
-ZROK_OAUTH_HASH_KEY=oauthhashkeysecret
-ZROK_OAUTH_GITHUB_CLIENT_ID=abcd1234
-ZROK_OAUTH_GITHUB_CLIENT_SECRET=abcd1234
-ZROK_OAUTH_GOOGLE_CLIENT_ID=abcd1234
-ZROK_OAUTH_GOOGLE_CLIENT_SECRET=abcd1234
+# optionally configure oauth for public shares
+#ZROK_OAUTH_HASH_KEY=oauthhashkeysecret
+#ZROK_OAUTH_GITHUB_CLIENT_ID=abcd1234
+#ZROK_OAUTH_GITHUB_CLIENT_SECRET=abcd1234
+#ZROK_OAUTH_GOOGLE_CLIENT_ID=abcd1234
+#ZROK_OAUTH_GOOGLE_CLIENT_SECRET=abcd1234
 
 # zrok version, e.g., 1.0.0
 ZROK_CLI_TAG=latest
@@ -223,22 +239,11 @@ See "My internet connection can only send traffic to common ports" below about c
 
 1. My DNS provider credential is composed of several values, not a single API token.
 
-    As long as your DNS provider is supported by Caddy then it will work. You can modify the Caddyfile to use a different set of properties than the example. Here's how the `tls` section should look for Route53. You must declare any environment variables introduced in the `.env` file in `docker.compose.override` on the `caddy` service to ensure they are passed through to the Caddy container.
+    As long as your DNS provider is supported by Caddy then it will work. Here's a checklist for DNS providers like Route53 with credentials expressed as multiple values, e.g., `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.
 
-    ```json
-    tls {
-      dns {$CADDY_DNS_PLUGIN} {
-        access_key_id {$AWS_ACCESS_KEY_ID}
-        secret_access_key {$AWS_SECRET_ACCESS_KEY}
-      }
-    }
-    ```
-
-    ```bash title=".env"
-    CADDY_DNS_PLUGIN=route53
-    AWS_ACCESS_KEY_ID=abcd1234
-    AWS_SECRET_ACCESS_KEY=abcd1234
-    ```
+    1. Define env vars in `.env` file.
+    1. Declare env vars in `compose.override.yml` file on `caddy`'s `environment`.
+    1. Modify `Caddyfile` according to the DNS plugin author's instructions ([link to Route53 README](https://github.com/caddy-dns/route53)). This means modifying the `Caddyfile` to reference the env vars. The provided file `route53.Caddyfile` serves as an example.
 
 1. My internet connection can only send traffic to common ports like 80, 443, and 3389.
 

--- a/docker/compose/zrok-instance/README.md
+++ b/docker/compose/zrok-instance/README.md
@@ -79,7 +79,7 @@ ZROK_FRONTEND_PORT=8080
 ZROK_OAUTH_PORT=8081
 
 # ziti ports must be published to the internet and allowed by firewall
-ZITI_CTRL_ADVERTISED_PORT=1280
+ZITI_CTRL_ADVERTISED_PORT=80
 ZITI_ROUTER_PORT=3022
 
 # configure oauth for public shares
@@ -157,13 +157,12 @@ The `ziti-quickstart` and `caddy` containers publish ports to all devices that u
 #### Required
 
 1. `443/tcp` - reverse proxy handles HTTPS requests for zrok API, OAuth, and public shares (published by container `caddy`)
-1. `1280/tcp` - ziti ctrl plane (published by container `ziti-quickstart`)
+1. `80/tcp` - ziti ctrl plane (published by container `ziti-quickstart`)
 1. `3022/tcp` - ziti data plane (published by container `ziti-quickstart`)
 
-#### Optional
-
-1. `80/tcp` - reverse proxy redirects non-HTTPS requests to `443/tcp` (published by container `caddy`)
 <!-- 1. 443/udp used by Caddy for HTTP/3 QUIC protocol (published by container `caddy`) -->
+
+See "My internet connection can only send traffic to common ports" below about changing the required ports.
 
 ### Troubleshooting
 
@@ -222,7 +221,7 @@ The `ziti-quickstart` and `caddy` containers publish ports to all devices that u
     docker compose exec caddy curl http://localhost:2019/config/ | jq
     ```
 
-1. My provider, e.g., Route53 doesn't give me a single API token.
+1. My DNS provider credential is composed of several values, not a single API token.
 
     As long as your DNS provider is supported by Caddy then it will work. You can modify the Caddyfile to use a different set of properties than the example. Here's how the `tls` section should look for Route53. You must declare any environment variables introduced in the `.env` file in `docker.compose.override` on the `caddy` service to ensure they are passed through to the Caddy container.
 
@@ -239,4 +238,13 @@ The `ziti-quickstart` and `caddy` containers publish ports to all devices that u
     CADDY_DNS_PLUGIN=route53
     AWS_ACCESS_KEY_ID=abcd1234
     AWS_SECRET_ACCESS_KEY=abcd1234
+    ```
+
+1. My internet connection can only send traffic to common ports like 80, 443, and 3389.
+
+    You can change the required ports in the `.env` file. Caddy will still use port 443 for zrok shares and API if you renamed `compose.caddy.yml` as `compose.override.yml` to enable Caddy.
+
+    ```bash title=".env"
+    ZITI_CTRL_ADVERTISED_PORT=80
+    ZITI_ROUTER_PORT=3389
     ```

--- a/docker/compose/zrok-instance/compose.caddy.yml
+++ b/docker/compose/zrok-instance/compose.caddy.yml
@@ -17,12 +17,12 @@ services:
       ZROK_FRONTEND_PORT: ${ZROK_FRONTEND_PORT:-8080}
       ZROK_OAUTH_PORT: ${ZROK_OAUTH_PORT:-8081}
     expose:
-      - 80/tcp
+      # - 80/tcp
       - 443/tcp
       - 443/udp   # Caddy's HTTP/3 (QUIC) (not published)
       - 2019/tcp  # Caddy's admin API     (not published)
     ports:
-      - ${CADDY_INTERFACE:-0.0.0.0}:80:80
+      # - ${CADDY_INTERFACE:-0.0.0.0}:80:80
       - ${CADDY_INTERFACE:-0.0.0.0}:443:443
       # - ${CADDY_INTERFACE:-0.0.0.0}:443:443/udp"  # future: HTTP/3 (QUIC)
     volumes:

--- a/docker/compose/zrok-instance/compose.caddy.yml
+++ b/docker/compose/zrok-instance/compose.caddy.yml
@@ -8,8 +8,21 @@ services:
         CADDY_DNS_PLUGIN: ${CADDY_DNS_PLUGIN} # e.g., "digitalocean" (see github.com/caddy-dns)
     restart: unless-stopped
     environment:
+      #
+      ## set these in .env for providers other than Route53
+      #
       CADDY_DNS_PLUGIN: ${CADDY_DNS_PLUGIN}  # e.g., "digitalocean" (see github.com/caddy-dns)
       CADDY_DNS_PLUGIN_TOKEN: ${CADDY_DNS_PLUGIN_TOKEN}  # API token from DNS provider used by plugin to solve the ACME challenge
+
+      #
+      ## for DNS providers like Route53 with multiple credential variables, you must define in .env and declare
+      ## here before referencing them in the Caddyfile
+      #
+      # AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      # AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      # AWS_REGION: ${AWS_REGION}
+      # AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}  # if temporary credential, e.g., from STS
+
       ZROK_USER_EMAIL: ${ZROK_USER_EMAIL}  # email address sent to CA for ACME account and renewal notifications
       CADDY_ACME_API: ${CADDY_ACME_API:-https://acme-v02.api.letsencrypt.org/directory}  # ACME API endpoint
       ZROK_DNS_ZONE: ${ZROK_DNS_ZONE}  # e.g., "example.com" or "127.0.0.1.sslip.io"

--- a/docker/compose/zrok-instance/compose.yml
+++ b/docker/compose/zrok-instance/compose.yml
@@ -14,7 +14,7 @@ services:
       - -euc
       - |
         ZITI_CMD+=" --ctrl-address ziti.${ZROK_DNS_ZONE}"\
-        " --ctrl-port ${ZITI_CTRL_ADVERTISED_PORT:-1280}"\
+        " --ctrl-port ${ZITI_CTRL_ADVERTISED_PORT:-80}"\
         " --router-address ziti.${ZROK_DNS_ZONE}"\
         " --router-port ${ZITI_ROUTER_PORT:-3022}"\
         " --password ${ZITI_PWD:-admin}"
@@ -31,10 +31,10 @@ services:
       # directory, ZITI_HOME 
       - ${ZITI_HOME:-ziti_home}:/home/ziggy
     ports:
-      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_CTRL_ADVERTISED_PORT:-1280}:${ZITI_CTRL_ADVERTISED_PORT:-1280}
+      - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_CTRL_ADVERTISED_PORT:-80}:${ZITI_CTRL_ADVERTISED_PORT:-80}
       - ${ZITI_INTERFACE:-0.0.0.0}:${ZITI_ROUTER_PORT:-3022}:${ZITI_ROUTER_PORT:-3022}
     expose:
-      - ${ZITI_CTRL_ADVERTISED_PORT:-1280}
+      - ${ZITI_CTRL_ADVERTISED_PORT:-80}
       - ${ZITI_ROUTER_PORT:-3022}
     depends_on:
       ziti-quickstart-init:
@@ -94,7 +94,7 @@ services:
         ZROK_CLI_IMAGE: ${ZROK_CLI_IMAGE:-openziti/zrok}
         ZROK_CLI_TAG: ${ZROK_CLI_TAG:-latest}
         ZROK_DNS_ZONE: ${ZROK_DNS_ZONE}  # e.g., "example.com" or "127.0.0.1.sslip.io"
-        ZITI_CTRL_ADVERTISED_PORT: ${ZITI_CTRL_ADVERTISED_PORT:-1280}
+        ZITI_CTRL_ADVERTISED_PORT: ${ZITI_CTRL_ADVERTISED_PORT:-80}
         ZROK_ADMIN_TOKEN: ${ZROK_ADMIN_TOKEN} # zrok controller admin password
         ZROK_CTRL_PORT: ${ZROK_CTRL_PORT:-18080}
         ZITI_PWD: ${ZITI_PWD} # ziti controller admin password
@@ -155,7 +155,7 @@ services:
       ZROK_API_ENDPOINT: http://zrok-controller:${ZROK_CTRL_PORT:-18080} # bridge address of the zrok controller
       ZROK_FRONTEND_SCHEME: http
       ZROK_FRONTEND_PORT: ${ZROK_FRONTEND_PORT:-8080}
-      ZITI_CTRL_ADVERTISED_PORT: ${ZITI_CTRL_ADVERTISED_PORT:-1280}
+      ZITI_CTRL_ADVERTISED_PORT: ${ZITI_CTRL_ADVERTISED_PORT:-80}
       ZITI_PWD: ${ZITI_PWD} # ziti controller admin password
 
 volumes:

--- a/docker/compose/zrok-instance/route53.Caddyfile
+++ b/docker/compose/zrok-instance/route53.Caddyfile
@@ -1,0 +1,51 @@
+{
+	email {$ZROK_USER_EMAIL}
+	acme_ca {$CADDY_ACME_API}
+	admin 0.0.0.0:2019
+}
+
+# http:// {
+# 	redir https://{host}{uri} permanent
+# }
+
+*.{$ZROK_DNS_ZONE} {
+	tls {
+		dns route53 {
+			access_key_id {$AWS_ACCESS_KEY_ID}
+			secret_access_key {$AWS_SECRET_ACCESS_KEY}
+			session_token {$AWS_SESSION_TOKEN}
+			region {$AWS_REGION}
+			# profile {$AWS_PROFILE}
+			# max_retries 10
+			# max_wait_dur 60
+			# wait_for_propagation false
+			# hosted_zone_id {$AWS_HOSTED_ZONE_ID}
+
+		}
+		propagation_timeout 60m
+	}
+
+	log {
+		output stdout
+		format console
+		level INFO
+	}
+
+	# ziti administration console uses :443 for the benefit of a web UI cert and accesses the ziti edge-management API
+	@ziti host ziti.{$ZROK_DNS_ZONE}
+	reverse_proxy @ziti ziti-quickstart:{$ZITI_CTRL_ADVERTISED_PORT:80} {
+		transport http {
+			tls_insecure_skip_verify
+		}
+	}
+
+	@oauth host oauth.{$ZROK_DNS_ZONE}
+	reverse_proxy @oauth zrok-frontend:{$ZROK_OAUTH_PORT}
+
+	@ctrl host zrok.{$ZROK_DNS_ZONE}
+	reverse_proxy @ctrl zrok-controller:{$ZROK_CTRL_PORT}
+
+	reverse_proxy zrok-frontend:{$ZROK_FRONTEND_PORT} {
+		header_up Host {http.request.host}
+	}
+}


### PR DESCRIPTION
- expand Docker instance doc around the special case of a DNS provider, e.g. Route53, that uses a credential composed of multiple values, like an id and secret, instead of a single value like an API token
- switch one of openziti ports from non-standard 1280/tcp to 80/tcp to reduce the need for non-standard egress port exceptions