### PR TITLE
refine windows installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGE: Use port 80 for the default Ziti API endpoint in the zrok Docker instanc
 
 CHANGE: Clarify OS requirements for zrok VPN
 
+CHANGE: Set the Windows executable search path in the Windows install guide.
+
 FEATURE: Linux service template for systemd user units (https://github.com/openziti/zrok/pull/818)
 
 ## v0.4.45

--- a/docs/guides/install/windows.mdx
+++ b/docs/guides/install/windows.mdx
@@ -18,21 +18,14 @@ import styles from '@site/src/css/download-card.module.css';
   </div>
 </AssetsProvider>
 
-1. Unarchive the distribution in a temporary directory:
+1. Extract `zrok.exe` to `%USERPROFILE%\bin` and set search `%PATH%`.
 
     ```text
-    New-Item -Path "$env:TEMP\zrok" -ItemType Directory -ErrorAction Stop
-    tar -xf .\zrok*windows*.tar.gz -C "$env:TEMP\zrok"
-    ```
-
-1. Install the `zrok` executable and include HOME\bin in the search PATH.
-
-    ```text
-    $source = Join-Path -Path $env:TEMP -ChildPath "zrok\zrok.exe"
-    $destination = Join-Path -Path $env:USERPROFILE -ChildPath "bin\zrok.exe"
-    New-Item -Path $destination -ItemType Directory -ErrorAction SilentlyContinue
-    Copy-Item -Path $source -Destination $destination
-    $env:path += ";"+$destination
+    $binDir = Join-Path -Path $env:USERPROFILE -ChildPath "bin"
+    New-Item -Path $binDir -ItemType Directory -ErrorAction SilentlyContinue
+    $latest = Get-ChildItem -Path .\zrok*windows*.tar.gz | Sort-Object LastWriteTime | Select-Object -Last 1
+    tar -xf $latest.FullName -C $binDir zrok.exe
+    $env:path += ";"+$binDir
     ```
 
 1. With the `zrok` executable in your path, you can then execute the `zrok` directly.
@@ -50,3 +43,16 @@ import styles from '@site/src/css/download-card.module.css';
 
     v0.4.0 [c889005]
     ```
+
+## Enable Your Environment
+
+Enable your environment without saving the account token in shell history, i.e., `zrok enable {token}`.
+
+```text
+$zrokAccountToken=Read-Host "Enter your zrok account token" -AsSecureString;
+zrok enable ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($zrokAccountToken)))
+```
+
+## Wintun for zrok VPN
+
+On Windows, you must install Wintun to use zrok's VPN backend mode. See the [VPN guide](/guides/vpn/vpn.md) for more details.

--- a/docs/guides/install/windows.mdx
+++ b/docs/guides/install/windows.mdx
@@ -18,14 +18,19 @@ import styles from '@site/src/css/download-card.module.css';
   </div>
 </AssetsProvider>
 
-1. Extract `zrok.exe` to `%USERPROFILE%\bin` and set search `%PATH%`.
+1. In PowerShell, install in `%USERPROFILE%\bin\zrok.exe` and set the search path.
 
     ```text
     $binDir = Join-Path -Path $env:USERPROFILE -ChildPath "bin"
     New-Item -Path $binDir -ItemType Directory -ErrorAction SilentlyContinue
     $latest = Get-ChildItem -Path .\zrok*windows*.tar.gz | Sort-Object LastWriteTime | Select-Object -Last 1
     tar -xf $latest.FullName -C $binDir zrok.exe
-    $env:path += ";"+$binDir
+    $currentPath = [System.Environment]::GetEnvironmentVariable('PATH', [System.EnvironmentVariableTarget]::User)
+    if ($currentPath -notlike "*$binDir*") {
+        $newPath = "$currentPath;$binDir"
+        [System.Environment]::SetEnvironmentVariable('PATH', $newPath, [System.EnvironmentVariableTarget]::User)
+        $env:Path = $newPath
+    }
     ```
 
 1. With the `zrok` executable in your path, you can then execute the `zrok` directly.
@@ -43,15 +48,6 @@ import styles from '@site/src/css/download-card.module.css';
 
     v0.4.0 [c889005]
     ```
-
-## Enable Your Environment
-
-Enable your environment without saving the account token in shell history, i.e., `zrok enable {token}`.
-
-```text
-$zrokAccountToken=Read-Host "Enter your zrok account token" -AsSecureString;
-zrok enable ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($zrokAccountToken)))
-```
 
 ## Wintun for zrok VPN
 


### PR DESCRIPTION
This fixes minor issues with the windows installation procedure. The problem was executable was unpacked in an awkward location, `%USERPROFILE%\bin\zrok.exe\zrok.exe`, and the path variable update was not persisted.