### PR TITLE
markdown tweaks

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with zrok
+title: Getting Started
 sidebar_label: Getting Started
 sidebar_position: 10
 ---
@@ -8,7 +8,7 @@ import { AssetsProvider } from '@site/src/components/assets-context';
 import DownloadCard from '@site/src/components/download-card';
 import DownloadCardStyles from '@site/src/css/download-card.module.css';
 
-## zrok is your secure internet sharing perimeter
+## Your Secure Internet Sharing Perimeter
 
 `zrok` (*/ziːɹɒk/ ZEE-rock*) is a secure, open-source, self-hostable sharing platform that simplifies shielding and sharing network services or files.
 There's a hardened zrok-as-a-service offering available at [myzrok.io](https://myzrok.io) with a generous free tier.
@@ -55,11 +55,13 @@ There's a hardened zrok-as-a-service offering available at [myzrok.io](https://m
     ```bash
     zrok enable <your_account_token>
     ```
+
 4. Share `http://localhost:8080`
 
     ```bash
     zrok share public 8080
     ```
+
 5. Visit the public URL displayed in your terminal
 
     ![zrok share public](images/zrok_share_public.png)
@@ -125,7 +127,7 @@ If [sharing privately](./concepts/sharing-private.mdx), only users with the shar
 
 ## Enabling Your zrok Environment
 
-After you have [an account](#zrok-is-your-secure-internet-sharing-perimeter), you can enable your `zrok` environment.
+After you have [an account](#your-first-share), you can enable your `zrok` environment.
 
 A zrok environment usually refers to an enabled device where shares and accesses can be created, .e.g., `~/.zrok` on a Unix machine. It can be a specific user's environment or a system-wide agent's environment owned by the administrator.
 
@@ -363,7 +365,7 @@ Here's a quick review of the `zrok` mental model and the vocabulary.
 
 You create an _account_ with a `zrok` _instance_. Your account is identified by a username and a password, which you use to log into the _web console_. Your account also has a _secret token_, which you will use to authenticate from the `zrok` command-line to interact with the _instance_.
 
-You create a new _account_ with NetFoundry's `zrok` _instance_ by subscribing in [myzrok.io](https://myzrok.io) or in a self-hosted `zrok` _instance_ by running [the `zrok invite` command](/guides/self-hosting/self-service-invite.mdx).
+You create a new _account_ with NetFoundry's `zrok` _instance_ by subscribing in [myzrok.io](https://myzrok.io) or in a self-hosted `zrok` _instance_ by running [the `zrok invite` command](/guides/self-hosting/self-service-invite.mdx) or the `zrok admin create account` command.
 
 ### Environment
 

--- a/docs/guides/self-hosting/self-service-invite.mdx
+++ b/docs/guides/self-hosting/self-service-invite.mdx
@@ -6,10 +6,10 @@ This is how to set up self-service invitations for your users to get an account 
 
 ## Overview
 
-- You can create user accounts directly with the `zrok admin` CLI or API.
+- You can create user accounts directly with the `zrok admin create account` CLI or API instead of inviting them.
 - You can welcome users to invite themselves via email.
-- You can generate invitation tokens if you want to restrict self-service invitations.
 - To enable self-service invitations you must also configure the controller to send email.
+- You can require an invitation token if you want to restrict self-service.
 
 ## The Self-Service User Experience
 


### PR DESCRIPTION
1. saying `zrok` in so many places feels redundant, so here's what it would look like with two fewer `zrok` mentions in the first few lines of the getting started page
2. for consistency, I used titular caps on the heading and surrounded certain markdown elements with empty lines
3. for clarity, I added some hints about creating accounts