### PR TITLE
api-v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ FEATURE: `zrok test canary` CLI tree replaces the old `zrok test loop` tree; new
 
 FEATURE: New `/api/v1/versions` endpoint to return comprehensive, full stack version information about the deployed service instance. Currently only returns a single `controllerVersion` property (https://github.com/openziti/zrok/issues/881) 
 
+CHANGE: The default API URL for `v1.0.x` zrok clients is now `https://api-v1.zrok.io` (instead of the older `https://api.zrok.io`). The zrok.io deployment will now be maintaining version-specific DNS for versioned API endpoints.
+
 CHANGE: Refactored API implementation. Cleanup, lint removal, additional data elements added, unused data removed (https://github.com/openziti/zrok/issues/834)
 
 CHANGE: Deprecated the `passwords` configuration stanza. The zrok controller and API console now use a hard-coded set of (what we believe to be) reasonable assumptions about password quality (https://github.com/openziti/zrok/issues/834)

--- a/docs/guides/self-hosting/instance-configuration.mdx
+++ b/docs/guides/self-hosting/instance-configuration.mdx
@@ -9,7 +9,7 @@ This guide is relevant if you are self-hosting or using a friend's `zrok` instan
 
 The `zrok` *command* on your computer uses a `zrok` *instance* over the network.
 
-The default instance API endpoint for the `zrok` command is `api.zrok.io`. Set the API endpoint to another instance's API endpoint:
+The default instance API endpoint for the `zrok` command is `api-v1.zrok.io`. Set the API endpoint to another instance's API endpoint:
 
 ```text
 zrok config set apiEndpoint https://zrok.example.com

--- a/docs/guides/self-hosting/linux/index.mdx
+++ b/docs/guides/self-hosting/linux/index.mdx
@@ -117,7 +117,7 @@ See the separate guides on [configuring metrics](/guides/self-hosting/metrics-an
 
 ## Environment Variables
 
-The `zrok` binaries are configured to work with the global `zrok.io` service, and default to using `api.zrok.io` as the endpoint for communicating with the service.
+The `zrok` binaries are configured to work with the global `zrok.io` service, and default to using `api-v1.zrok.io` as the endpoint for communicating with the service.
 
 To work with a self-hosted `zrok` deployment, you'll need to set the `ZROK_API_ENDPOINT` environment variable to point to the address where your `zrok` controller will be listening, according to `endpoint` in the configuration file above.
 

--- a/environment/env_v0_3/api.go
+++ b/environment/env_v0_3/api.go
@@ -62,7 +62,7 @@ func (r *Root) Client() (*rest_client_zrok.Zrok, error) {
 }
 
 func (r *Root) ApiEndpoint() (string, string) {
-	apiEndpoint := "https://api.zrok.io"
+	apiEndpoint := "https://api-v1.zrok.io"
 	from := "binary"
 
 	if r.Config() != nil && r.Config().ApiEndpoint != "" {

--- a/environment/env_v0_4/api.go
+++ b/environment/env_v0_4/api.go
@@ -61,7 +61,7 @@ func (r *Root) Client() (*rest_client_zrok.Zrok, error) {
 }
 
 func (r *Root) ApiEndpoint() (string, string) {
-	apiEndpoint := "https://api.zrok.io"
+	apiEndpoint := "https://api-v1.zrok.io"
 	from := "binary"
 
 	if r.Config() != nil && r.Config().ApiEndpoint != "" {

--- a/nfpm/zrok-enable.bash
+++ b/nfpm/zrok-enable.bash
@@ -51,7 +51,7 @@ if [[ -z "${ZROK_ENABLE_TOKEN}" ]]; then
   echo "ERROR: ZROK_ENABLE_TOKEN is not defined" >&2
   exit 1
 else
-  zrok config set apiEndpoint "${ZROK_API_ENDPOINT:-https://api.zrok.io}"
+  zrok config set apiEndpoint "${ZROK_API_ENDPOINT:-https://api-v1.zrok.io}"
   echo "INFO: running: zrok enable ..."
   exec zrok enable --headless --description "${ZROK_ENVIRONMENT_NAME:-${DEFAULT_ZROK_ENVIRONMENT_NAME}}" "${ZROK_ENABLE_TOKEN}"
 fi

--- a/nfpm/zrok-share.env
+++ b/nfpm/zrok-share.env
@@ -20,7 +20,7 @@ ZROK_ENABLE_TOKEN=""
 ZROK_ENVIRONMENT_NAME=""
 
 # You MUST set this if not using the default API endpoint
-#ZROK_API_ENDPOINT="https://api.zrok.io"
+#ZROK_API_ENDPOINT="https://api-v1.zrok.io"
 
 #
 ## ZROK BACKEND MODE AND TARGET
@@ -88,7 +88,7 @@ ZROK_TARGET=""                  # e.g., http://127.0.0.1:3000
 # WARNING: changes take effect the next time the frontend URL is reserved
 #ZROK_UNIQUE_NAME=""
 
-# you MAY set one OAuth2/OIDC provider; "google" and "github" are valid for the default instance api.zrok.io
+# you MAY set one OAuth2/OIDC provider; "google" and "github" are valid for the default instance api-v1.zrok.io
 # WARNING: changes take effect the next time the frontend URL is reserved
 # NOTE: basic auth and oauth are mutually exclusive
 #ZROK_OAUTH_PROVIDER="google"

--- a/sdk/nodejs/sdk/src/environment/root.ts
+++ b/sdk/nodejs/sdk/src/environment/root.ts
@@ -76,7 +76,7 @@ export class Root {
     }
 
     public ApiEndpoint(): ApiEndpoint {
-        let apiEndpoint = "https://api.zrok.io"
+        let apiEndpoint = "https://api-v1.zrok.io"
         let frm = "binary"
 
         if (this.cfg.ApiEndpoint != "") {

--- a/sdk/python/examples/pastebin/README.md
+++ b/sdk/python/examples/pastebin/README.md
@@ -4,7 +4,7 @@ This example shows the use of the zrok SDK spinning up a simple pastebin command
 
 ## Self-hosting Setup :wrench:
 
-You don't need this section if you're using hosted zrok from NetFoundry (https://api.zrok.io/).
+You don't need this section if you're using hosted zrok from NetFoundry (https://api-v1.zrok.io/).
 
 Refer to the [setup guide](../../../docs/guides/self-hosting/self_hosting_guide.md) for details on setting up your zrok
 environment if you're self-hosting zrok.

--- a/sdk/python/sdk/zrok/zrok/environment/root.py
+++ b/sdk/python/sdk/zrok/zrok/environment/root.py
@@ -61,7 +61,7 @@ class Root:
         return zrock_client
 
     def ApiEndpoint(self) -> ApiEndpoint:
-        apiEndpoint = "https://api.zrok.io"
+        apiEndpoint = "https://api-v1.zrok.io"
         frm = "binary"
 
         if self.cfg.ApiEndpoint != "":


### PR DESCRIPTION
The default URL is now `https://api-v1.zrok.io`.