### PR TITLE
V1 nodejs sdk ci

### DIFF
--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -54,20 +54,20 @@ jobs:
         fetch-depth: 0
 
     - name: Get current zrok repo tag
-      if: github.ref_type == 'tag'
+      if: github.event.action == 'released'
       id: tag
       shell: bash
       run: echo "TAG=$(git describe --tags --always)" | tee -a $GITHUB_OUTPUT
 
     - name: Update zrok NodeJS-SDK's package.json version based on current zrok repo git tag
-      if: github.ref_type == 'tag'
+      if: github.event.action == 'released'
       shell: bash
       run: |
         cd sdk/nodejs/sdk
         npm version ${{ steps.tag.outputs.TAG }} --no-git-tag-version --allow-same-version
 
     - name: Setup .npmrc
-      if: github.ref_type == 'tag'
+      if: github.event.action == 'released'
       # Setup .npmrc file to prepare for possible publish to npm
       uses: actions/setup-node@v4
       with:
@@ -84,7 +84,7 @@ jobs:
         BUILD_DATE: ${{ steps.date.outputs.date }}
 
     - name: NPM Publish
-      if: github.ref_type == 'tag'
+      if: github.event.action == 'released'
       shell: bash
       run: |
         cd sdk/nodejs/sdk

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -57,6 +57,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: 'recursive'
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Get current zrok repo tag
       id: tag

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -33,10 +33,10 @@ jobs:
     name: Build for Node-${{ matrix.node_ver }} ${{ matrix.config.target }}/${{ matrix.config.arch }}
     runs-on: ${{ matrix.config.runs-on }}
     container: ${{ matrix.config.container }}
-
     env:
       BUILD_NUMBER: ${{ github.run_number }}
       AWS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      # GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     
     strategy:
       matrix:
@@ -54,10 +54,14 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: 'recursive'
-        token: ${{ secrets.GITHUB_TOKEN }}
+      # with:
+      #   fetch-depth: 0
+      #   submodules: recursive
+      #   token: ${{ secrets.GITHUB_TOKEN }}
+
+    # - name: Configure Git Authentication
+    #   run: |
+    #     git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "https://github.com/"
 
     - name: Get current zrok repo tag
       id: tag

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -36,15 +36,14 @@ jobs:
     env:
       BUILD_NUMBER: ${{ github.run_number }}
       AWS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      # GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    
+
     strategy:
       matrix:
         config:
           - { runs-on: ubuntu-24.04, container: openziti/ziti-builder:v2, target: "linux", arch: "x64" }
         node_ver: [ 20 ]
       fail-fast: false
-    
+
     steps:
 
     - name: Node Version
@@ -56,12 +55,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-      #   submodules: recursive
-      #   token: ${{ secrets.GITHUB_TOKEN }}
-
-    # - name: Configure Git Authentication
-    #   run: |
-    #     git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "https://github.com/"
 
     - name: Get current zrok repo tag
       if: github.ref_type == 'tag'

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -29,8 +29,7 @@ jobs:
     needs: enforce_stable_semver
     if: always()
     name: Build for Node-${{ matrix.node_ver }} ${{ matrix.config.target }}/${{ matrix.config.arch }}
-    runs-on: ${{ matrix.config.runs-on }}
-    container: ${{ matrix.config.container }}
+    runs-on: ${{ matrix.config.os }}
     env:
       BUILD_NUMBER: ${{ github.run_number }}
       AWS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -38,7 +37,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - { runs-on: ubuntu-24.04, container: openziti/ziti-builder:v2, target: "linux", arch: "x64" }
+          - { os: ubuntu-24.04, target: "linux", arch: "x64" }
         node_ver: [ 20 ]
       fail-fast: false
 

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -54,8 +54,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
-      # with:
-      #   fetch-depth: 0
+      with:
+        fetch-depth: 0
       #   submodules: recursive
       #   token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -64,13 +64,14 @@ jobs:
     #     git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "https://github.com/"
 
     - name: Get current zrok repo tag
+      if: github.ref_type == 'tag'
       id: tag
-      run: echo "TAG=$(git describe --tags --abbrev=0)" | tee -a $GITHUB_OUTPUT
+      run: echo "TAG=$(git describe --tags --always)" | tee -a $GITHUB_OUTPUT
 
     - name: Update zrok NodeJS-SDK's package.json version based on current zrok repo git tag
       if: github.ref_type == 'tag'
       run: |
-        cd ${{ runner.workspace }}/${{ github.event.repository.name }}/sdk/nodejs/sdk
+        cd sdk/nodejs/sdk
         npm version ${{ steps.tag.outputs.TAG }} --no-git-tag-version --allow-same-version
 
     - name: Setup .npmrc
@@ -83,7 +84,7 @@ jobs:
 
     - name: Build the zrok NodeJS-SDK
       run: |
-        cd ${{ runner.workspace }}/${{ github.event.repository.name }}/sdk/nodejs/sdk
+        cd sdk/nodejs/sdk
         npm install
         npm run build
       env:
@@ -92,7 +93,7 @@ jobs:
     - name: NPM Publish
       if: github.ref_type == 'tag'
       run: |
-        cd ${{ runner.workspace }}/${{ github.event.repository.name }}/sdk/nodejs/sdk
+        cd sdk/nodejs/sdk
         npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -88,6 +88,13 @@ jobs:
       shell: bash
       run: |
         cd sdk/nodejs/sdk
-        npm publish --access public
+        # Check if this is the official repository
+        if [[ "${{ github.repository_owner }}" == "openziti" ]]; then
+          echo "Publishing from official repository with @latest tag"
+          npm publish --access public
+        else
+          echo "Publishing from fork/test repository with @canary tag"
+          npm publish --access public --tag canary
+        fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -31,7 +31,8 @@ jobs:
     needs: enforce_stable_semver
     if: always()
     name: Build for Node-${{ matrix.node_ver }} ${{ matrix.config.target }}/${{ matrix.config.arch }}
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.config.runs-on }}
+    container: ${{ matrix.config.container }}
 
     env:
       BUILD_NUMBER: ${{ github.run_number }}
@@ -40,7 +41,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - { os: ubuntu-20.04,   target: "linux", arch: "x64" }
+          - { runs-on: ubuntu-24.04, container: openziti/ziti-builder:v2, target: "linux", arch: "x64" }
         node_ver: [ 20 ]
       fail-fast: false
     

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -12,8 +12,6 @@ jobs:
     name: Require Stable Release Semver
     if: github.event.action == 'released'
     runs-on: ubuntu-24.04
-    outputs:
-      version: ${{ steps.parse.outputs.version }}
     steps:
       - name: Parse Release Version
         id: parse
@@ -59,10 +57,12 @@ jobs:
     - name: Get current zrok repo tag
       if: github.ref_type == 'tag'
       id: tag
+      shell: bash
       run: echo "TAG=$(git describe --tags --always)" | tee -a $GITHUB_OUTPUT
 
     - name: Update zrok NodeJS-SDK's package.json version based on current zrok repo git tag
       if: github.ref_type == 'tag'
+      shell: bash
       run: |
         cd sdk/nodejs/sdk
         npm version ${{ steps.tag.outputs.TAG }} --no-git-tag-version --allow-same-version
@@ -76,6 +76,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Build the zrok NodeJS-SDK
+      shell: bash
       run: |
         cd sdk/nodejs/sdk
         npm install
@@ -85,6 +86,7 @@ jobs:
 
     - name: NPM Publish
       if: github.ref_type == 'tag'
+      shell: bash
       run: |
         cd sdk/nodejs/sdk
         npm publish --access public


### PR DESCRIPTION
- stop uploading canary releases to npm as `@latest`
- stop using end-of-life github runner
- stop suppressing exceptions from in-line shell run steps