### PR TITLE
Hyphens are not allowed in zrok reserve unique names

### DIFF
--- a/docs/guides/_frontdoor-linux.mdx
+++ b/docs/guides/_frontdoor-linux.mdx
@@ -59,10 +59,10 @@ ZROK_ENABLE_TOKEN="14cbfca9772f"
 
 ## Name your Share
 
-This unique name becomes part of the domain name of the share, e.g. `https://my-prod-app.in.zrok.io`. A random name is generated if you don't specify one.
+This unique name becomes part of the domain name of the share, e.g. `https://myprodapp.in.zrok.io`. A random name is generated if you don't specify one.
 
 ```bash title="/opt/openziti/etc/zrok/zrok-share.env"
-ZROK_UNIQUE_NAME="my-prod-app"
+ZROK_UNIQUE_NAME="myprodapp"
 ```
 
 ## Use Cases

--- a/website/versioned_docs/version-0.4/guides/_frontdoor-linux.mdx
+++ b/website/versioned_docs/version-0.4/guides/_frontdoor-linux.mdx
@@ -59,10 +59,10 @@ ZROK_ENABLE_TOKEN="14cbfca9772f"
 
 ## Name your Share
 
-This unique name becomes part of the domain name of the share, e.g. `https://my-prod-app.in.zrok.io`. A random name is generated if you don't specify one.
+This unique name becomes part of the domain name of the share, e.g. `https://myprodapp.in.zrok.io`. A random name is generated if you don't specify one.
 
 ```bash title="/opt/openziti/etc/zrok/zrok-share.env"
-ZROK_UNIQUE_NAME="my-prod-app"
+ZROK_UNIQUE_NAME="myprodapp"
 ```
 
 ## Use Cases


### PR DESCRIPTION
I ran into a small issue setting up a linux systemd based zrok public share today. I followed the docs and made a unique name with a hyphen in it, causing the following error

```sh
zrok reserve public -n my-prod-app 3001
[ERROR] invalid unique name; must be lowercase alphanumeric, between 4 and 32 characters in length, screened for profanity
```

Figured I'd open a quick PR for ya.

Great software, appreciate all thats been put together with this project.