### PR TITLE
Auto-rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.0.2
 
+FEATURE: "Auto-rebase" for enabled environments where the `apiEndpoint` is set to `https://api.zrok.io`. This will automatically migrate existing environments to the new `apiEndpoint` for the `v1.0.x` series (https://github.com/openziti/zrok/issues/936)
+
 FEATURE: New `admin/new_account_link` configuration option to allow the insertion of "how do I register for an account?" links into the login form (https://github.com/openziti/zrok/issues/552)
 
 CHANGE: The release environment, share, and access modals in the API console now have a better message letting the user know they will still need to clean up their `zrok` processes (https://github.com/openziti/zrok/issues/910)

--- a/environment/env_v0_4/root.go
+++ b/environment/env_v0_4/root.go
@@ -6,8 +6,10 @@ import (
 	"github.com/openziti/zrok/environment/env_core"
 	"github.com/openziti/zrok/environment/env_v0_3"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const V = "v0.4"
@@ -285,6 +287,13 @@ func loadEnvironment() (*env_core.Environment, error) {
 		AccountToken: env.AccountToken,
 		ZitiIdentity: env.ZId,
 		ApiEndpoint:  env.ApiEndpoint,
+	}
+	if strings.HasPrefix(env.ApiEndpoint, "https://api.zrok.io") {
+		out.ApiEndpoint = "https://api-v1.zrok.io"
+		if err := saveEnvironment(out); err != nil {
+			return nil, errors.Wrap(err, "error auto-rebasing apiEndpoint")
+		}
+		logrus.Info("auto-rebased 'apiEndpoint' for v1.0.x")
 	}
 	return out, nil
 }


### PR DESCRIPTION
Automatically rebase to the correct `apiEndpoint` for `v1.0.x` clients (see #936).