### PR TITLE
Update config version to match latest expected by zrok admin bootstrap

### DIFF
--- a/docs/guides/self-hosting/linux/index.mdx
+++ b/docs/guides/self-hosting/linux/index.mdx
@@ -68,7 +68,7 @@ Create a `zrok` controller configuration file in `etc/ctrl.yml`. The controller 
 #   /___|_|  \___/|_|\_\
 # controller configuration
 
-v:                  3
+v:                  4
 
 admin:
   # generate these admin tokens from a source of randomness, e.g. 


### PR DESCRIPTION
While following the [self-hosting guide](https://docs.zrok.io/docs/guides/self-hosting/linux/#configure-the-controller), I encountered the following error when running `zrok admin bootstrap /etc/ctrl.yml`:

`panic: expecting configuration version '4', your configuration is version '3'; please see zrok.io for changelog and configuration documentation`

