### PR TITLE
zrok agent console Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.0.3
 
+FEATURE: `zrok agent console` now outputs the URL it is attempting to open. New `zrok agent console --headless` option to only emit the agent console URL (https://github.com/openziti/zrok/issues/944)
+
 FEATURE: New `zrok admin unbootstrap` to remove zrok resources from the underlying OpenZiti instance (https://github.com/openziti/zrok/issues/935)
 
 FEATURE: New InfluxDB metrics capture infrastructure for `zrok test canary` framework (https://github.com/openziti/zrok/issues/948)

--- a/cmd/zrok/agentConsole.go
+++ b/cmd/zrok/agentConsole.go
@@ -15,7 +15,8 @@ func init() {
 }
 
 type agentConsoleCommand struct {
-	cmd *cobra.Command
+	cmd      *cobra.Command
+	headless bool
 }
 
 func newAgentConsoleCommand() *agentConsoleCommand {
@@ -24,7 +25,8 @@ func newAgentConsoleCommand() *agentConsoleCommand {
 		Short: "Open the Agent console",
 		Args:  cobra.NoArgs,
 	}
-	command := &agentConsoleCommand{cmd}
+	command := &agentConsoleCommand{cmd: cmd}
+	cmd.Flags().BoolVar(&command.headless, "headless", false, "Do not attempt to open console, just emit console URL")
 	cmd.Run = command.run
 	return command
 }
@@ -46,7 +48,12 @@ func (cmd *agentConsoleCommand) run(_ *cobra.Command, _ []string) {
 		tui.Error("error getting agent version", err)
 	}
 
-	if err := openBrowser("http://" + v.ConsoleEndpoint); err != nil {
-		tui.Error(fmt.Sprintf("unable to open agent console at 'http://%v'", v.ConsoleEndpoint), err)
+	if cmd.headless {
+		fmt.Println("http://" + v.ConsoleEndpoint)
+	} else {
+		fmt.Printf("opening default web browser for: http://%v\n", v.ConsoleEndpoint)
+		if err := openBrowser("http://" + v.ConsoleEndpoint); err != nil {
+			tui.Error(fmt.Sprintf("unable to open agent console at 'http://%v'", v.ConsoleEndpoint), err)
+		}
 	}
 }


### PR DESCRIPTION
Output console URL by default; new `--headless` mode, which _only_ emits the URL (#944).