### PR TITLE
Remove Rebase Note from Getting Started

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -9,17 +9,6 @@ import DownloadCard from '@site/src/components/download-card';
 import DownloadCardStyles from '@site/src/css/download-card.module.css';
 import InstallCards from '/../docs/guides/install/_install_cards.mdx';
 
-:::note
-If you've upgraded to `v1.0.0` from a previous version and you receive an error message like this:
-
-```
-[ERROR]: unable to create share (error getting zrok client: client version error accessing api endpoint 'https://api.zrok.io': [POST /clientVersionCheck] clientVersionCheck (status 404): {}: [POST /clientVersionCheck] clientVersionCheck (status 404): {})
-```
-
-Use the command `zrok rebase apiEndpoint https://api-v1.zrok.io/` to update your environment to the latest zrok endpoint.
-:::
-
-
 ## Your Secure Internet Sharing Perimeter
 
 `zrok` (*/ziːɹɒk/ ZEE-rock*) is a secure, open-source, self-hostable sharing platform that simplifies shielding and sharing network services or files.


### PR DESCRIPTION
This is no longer necessary. Auto-rebasing versions of zrok have been available for weeks now.