### PR TITLE
start of 'v1.1.x' series

### DIFF
--- a/build/metadata.go
+++ b/build/metadata.go
@@ -5,7 +5,7 @@ import "fmt"
 var Version string
 var Hash string
 
-const Series = "v1.0"
+const Series = "v1.1"
 
 func String() string {
 	if Version != "" {


### PR DESCRIPTION
Start `v1.1.x` stream. Manage compatibility check for `v1.0.x` stream.

See #1020 