### PR TITLE
v1.1.1 Client Compatibility Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.1.1
+
+FIX: Masquerade as `v1.0-v1.1.1 [gitHash]` when performing client version checks. Will be replaced with the usual client identifier in `v1.1.2` when the regular expressions for controlling client compatibility are externalized in the controller config (https://github.com/openziti/zrok/issues/1028)
+
 ## v1.1.0
 
 FEATURE: Rewritten and improved `publicProxy` package (`zrok access public`), with support for extensible OAuth-compliant identity providers. The `publicProxy` configuration now supports any number of configured OAuth-compliant providers (rather than just a single `google` provider and/or a single `github` provider). Also includes a new OIDC-compliant generic IDP provider integration. Improvements to authentication flows and security all around. See the [updated guide](https://docs.zrok.io/docs/guides/self-hosting/oauth/configuring-oauth/) on using OAuth-based identity providers with the zrok public frontend (https://github.com/openziti/zrok/issues/968)

--- a/environment/env_v0_3/api.go
+++ b/environment/env_v0_3/api.go
@@ -1,6 +1,7 @@
 package env_v0_3
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -52,7 +53,7 @@ func (r *Root) Client() (*rest_client_zrok.Zrok, error) {
 	zrok := rest_client_zrok.New(transport, strfmt.Default)
 	_, err = zrok.Metadata.ClientVersionCheck(&metadata2.ClientVersionCheckParams{
 		Body: metadata2.ClientVersionCheckBody{
-			ClientVersion: build.String(),
+			ClientVersion: fmt.Sprintf("v1.0-%s", build.String()), // TODO: go back to build.String()
 		},
 	})
 	if err != nil {

--- a/environment/env_v0_4/api.go
+++ b/environment/env_v0_4/api.go
@@ -1,6 +1,7 @@
 package env_v0_4
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -52,7 +53,7 @@ func (r *Root) Client() (*rest_client_zrok.Zrok, error) {
 	zrok := rest_client_zrok.New(transport, strfmt.Default)
 	_, err = zrok.Metadata.ClientVersionCheck(&metadata2.ClientVersionCheckParams{
 		Body: metadata2.ClientVersionCheckBody{
-			ClientVersion: build.String(),
+			ClientVersion: fmt.Sprintf("v1.0-%s", build.String()), // TODO: go back to build.String()
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
See #1028 

Temporary fix to allow `v1.1.1` to masquerade as `v1.0-v1.1.1...` allowing it to pass client compatibility checks.

`v1.1.2` will introduce externalized regular expressions for managing client compatibility in the controller configuration, allowing for fine-grained, post-build compatibility management.