### PR TITLE
use new zhook url

### DIFF
--- a/.github/workflows/mattermost-webhook.yml
+++ b/.github/workflows/mattermost-webhook.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     name: POST Webhook
     steps:
-    - uses: openziti/ziti-mattermost-action-py@main
+    - uses: openziti/ziti-mattermost-action-py@v1
       if: |
         github.repository_owner == 'openziti'
         && ((github.event_name != 'pull_request_review')


### PR DESCRIPTION
- adopt the new url so we don't have to change zrok workflows again when the old one is turned off
- configure the action for minimum noise, esp. related to false failures