### PR TITLE
Fix API console's favicon path

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="/img/zrok.png" />
+		<link rel="icon" type="image/svg+xml" href="/zrok.png" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">


### PR DESCRIPTION
This fixes the path of the favicon of the API console, which previously tried to access `/img/zrok.png`, when the file is actually located at `ui/public/zrok.png` (not in an `img` subdirectory).