### PR TITLE
Update http frontend configuration version to 4

### DIFF
--- a/docs/guides/self-hosting/linux/index.mdx
+++ b/docs/guides/self-hosting/linux/index.mdx
@@ -224,7 +224,7 @@ Nice work! The `zrok` controller is fully configured now that you have created t
 Create an http frontend configuration file in `etc/http-frontend.yml`.
 
 ```yaml
-v:                  3
+v:                  4
 host_match:         zrok.quigley.com
 address:            0.0.0.0:8080
 ```


### PR DESCRIPTION
Not sure from which zrok version this became a requirement but I'm currently running **zrok 1.1.5** and noticed `zrok access public` did no longer work with a v3 config.

`[ERROR]: unable to load configuration '/etc/http-frontend.yml' (invalid configuration version '3'; expected '4')`