### PR TITLE
Enable CGO for Linux builds and improve unique name validation

### DIFF
--- a/docker/images/cross-build/linux-build.sh
+++ b/docker/images/cross-build/linux-build.sh
@@ -59,7 +59,7 @@ fi
 
 for ARCH in "${JOBS[@]}"; do
     LDFLAGS="-s -w -X 'github.com/openziti/zrok/build.Version=${VERSION}' -X 'github.com/openziti/zrok/build.Hash=${HASH}'"
-    GOOS=linux GOARCH=$(resolveArch "${ARCH}") \
+    CGO_ENABLED=1 GOOS=linux GOARCH=$(resolveArch "${ARCH}") \
     go build -o "./dist/$(resolveArch "${ARCH}")/linux/zrok" \
     -ldflags "${LDFLAGS}" \
     ./cmd/zrok

--- a/util/uniqueName.go
+++ b/util/uniqueName.go
@@ -5,9 +5,9 @@ import (
 	"regexp"
 )
 
-// IsValidUniqueName ensures that the string represents a valid unique name. Lowercase alphanumeric only. 4-32 characters.
+// IsValidUniqueName ensures that the string represents a valid unique name. Lowercase alphanumeric and hyphens. 3-36 characters.
 func IsValidUniqueName(uniqueName string) bool {
-	match, err := regexp.Match("^[a-z0-9]{4,32}$", []byte(uniqueName))
+	match, err := regexp.Match("^[a-z0-9-]{3,36}$", []byte(uniqueName))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## Summary

This PR includes two improvements to the zrok project:

### 1. Enable CGO for Linux builds
- Added `CGO_ENABLED=1` to `docker/images/cross-build/linux-build.sh`
- This ensures proper compilation of sqlite3 bindings and CGO-dependent packages
- Fixes issues where `sqlite3.Error` types were inaccessible during cross-compilation

### 2. Improve unique name validation
- Updated `util/uniqueName.go` to accept hyphens in unique names
- Changed length requirement from 4-32 to 3-36 characters
- Updated regex pattern from `^[a-z0-9]{4,32}$` to `^[a-z0-9-]{3,36}$`

## Technical Details

The CGO_ENABLED flag was previously not set in the Linux build script, which caused issues when cross-compiling packages that depend on C libraries (like mattn/go-sqlite3). By explicitly enabling CGO, we ensure that:
- The sqlite3 package compiles correctly with its C bindings
- Error types like `sqlite3.Error` and constants like `sqlite3.ErrConstraint` are properly accessible
- Cross-compilation works correctly with the zrok-builder Docker image

## Testing

- Successfully built Linux binaries for amd64 architecture
- Verified sqlite3 error handling works correctly in controller/createFrontend.go
- Built and published Docker images to GitHub Container Registry