### PR TITLE
fix: update go-m1cpu v0.1.6 to v0.2.1 to fix SIGSEGV on macOS Tahoe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -214,7 +214,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/russellhaering/goxmldsig v1.5.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect

--- a/go.sum
+++ b/go.sum
@@ -818,10 +818,10 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
-github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
-github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
-github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
-github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shoenig/go-m1cpu v0.2.1 h1:yqRB4fvOge2+FyRXFkXqsyMoqPazv14Yyy+iyccT2E4=
+github.com/shoenig/go-m1cpu v0.2.1/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
+github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
+github.com/shoenig/test v1.7.0/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=


### PR DESCRIPTION
## Summary

- Upgrades indirect dependency `github.com/shoenig/go-m1cpu` from **v0.1.6** to **v0.2.1**
- Fixes a `SIGSEGV` (segmentation violation) that makes all zrok binaries crash immediately on **macOS 26 (Tahoe)** with Apple M5 chips
- The crash occurs during `init()` before `main()` runs, so no zrok command works at all on affected systems

## Root cause

`go-m1cpu` v0.1.6 (May 2023) calls `sysctlbyname` via cgo during package initialization to detect Apple Silicon CPU features. On macOS 26 Tahoe with M5 processors, this call triggers a segmentation fault at address `0x0`.

The upstream fix was released in:
- [go-m1cpu v0.2.0](https://github.com/shoenig/go-m1cpu/releases/tag/v0.2.0) (Mar 11, 2026) — "fix segfault with m5 cpu"
- [go-m1cpu v0.2.1](https://github.com/shoenig/go-m1cpu/releases/tag/v0.2.1) (Mar 17, 2026) — "fix CFRelease NULL crash on M5 Pro/Max"

This is a transitive dependency pulled in by `shirou/gopsutil/v3`.

## Crash stack trace (before fix)

```
SIGSEGV: segmentation violation
PC=0x1847094f8 m=0 sigcode=2 addr=0x0
signal arrived during cgo execution

goroutine 1 [syscall, locked to thread]:
runtime.cgocall(...)
github.com/shoenig/go-m1cpu._Cfunc_initialize()
github.com/shoenig/go-m1cpu.init.0()
```

## Environment

- macOS 26.3.1 (Tahoe), Darwin 25.3.0
- Apple M5 (arm64)
- Affected: zrok v2.0.1 release binaries, Homebrew zrok 1.1.11
- Verified: building from source with go-m1cpu v0.2.1 resolves the crash

## Changes

Only `go.mod` and `go.sum` — no code changes:

```
go get github.com/shoenig/go-m1cpu@v0.2.1
go mod tidy
```

## Test plan

- [x] Built from source with the updated dependency on macOS Tahoe (arm64)
- [x] `zrok2 version` runs without crash
- [ ] CI passes (this change only bumps a transitive dependency with no API changes)