### PR TITLE
fix for python sdk 'ProxyShare' absolute paths; python sdk test fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v2.0.3
 
+FIX: The Python SDK `ProxyShare` now rejects absolute proxy request paths before forwarding. This prevents a viewer from using an absolute URL path to make the proxy host request arbitrary internal or loopback services instead of the configured target.
+
+FIX: Updated Python SDK unit tests to patch `zrok2.*` modules instead of the legacy `zrok.*` package path, allowing the non-integration test suite to pass against the v2 Python package layout.
+
 FIX: Frontends configured with `interstitial.user_agent_prefixes` no longer suppress the interstitial page for all requests. The prefix list is now correctly evaluated as an allow-list of User-Agents that should receive the page; if the list is empty all User-Agents receive it, matching the documented behavior.
 
 FIX: Updated `github.com/shoenig/go-m1cpu` to v0.2.1 to correct segmentation violation on M5 macos systems.

--- a/sdk/python/src/zrok2/proxy.py
+++ b/sdk/python/src/zrok2/proxy.py
@@ -38,6 +38,23 @@ HOP_BY_HOP_HEADERS = {
 DUMMY_PORT = 18081
 
 
+def _target_url(target: str, path: str) -> str:
+    target_parts = urllib.parse.urlsplit(target)
+    if not target_parts.scheme or not target_parts.netloc:
+        raise ValueError("proxy target must include a scheme and host")
+
+    path_parts = urllib.parse.urlsplit(path)
+    if path_parts.scheme or path_parts.netloc:
+        raise ValueError("absolute proxy paths are not allowed")
+
+    url = urllib.parse.urljoin(target, path)
+    url_parts = urllib.parse.urlsplit(url)
+    if url_parts.scheme != target_parts.scheme or url_parts.netloc != target_parts.netloc:
+        raise ValueError("proxy path escapes configured target")
+
+    return url
+
+
 @dataclass
 class ProxyShare:
     """Represents a proxy share with its configuration and state."""
@@ -150,8 +167,10 @@ class ProxyShare:
         @app.route('/', defaults={'path': ''}, methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'])
         @app.route('/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'])
         def proxy(path):
-            # Construct the target URL
-            url = urllib.parse.urljoin(self.target, path)
+            try:
+                url = _target_url(self.target, path)
+            except ValueError:
+                return Response("bad proxy path", status=400)
 
             # Forward the request
             resp = requests.request(

--- a/sdk/python/tests/test_access.py
+++ b/sdk/python/tests/test_access.py
@@ -1,4 +1,4 @@
-"""Tests for zrok.access — CreateAccess, DeleteAccess, Access context manager."""
+"""Tests for zrok2.access — CreateAccess, DeleteAccess, Access context manager."""
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -22,7 +22,7 @@ class TestCreateAccess:
 
         req = model.AccessRequest(ShareToken="shr_abc")
 
-        with patch("zrok.access.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.access.ShareApi", return_value=mock_share_api):
             acc = CreateAccess(mock_root, req)
             assert acc.Token == "fe_tok"
             assert acc.ShareToken == "shr_abc"
@@ -34,7 +34,7 @@ class TestCreateAccess:
 
         req = model.AccessRequest(ShareToken="shr_bad")
 
-        with patch("zrok.access.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.access.ShareApi", return_value=mock_share_api):
             with pytest.raises(Exception, match="unable to create access"):
                 CreateAccess(mock_root, req)
 
@@ -44,7 +44,7 @@ class TestDeleteAccess:
         mock_share_api = MagicMock()
         acc = model.Access(Token="fe_tok", ShareToken="shr_abc", BackendMode="proxy")
 
-        with patch("zrok.access.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.access.ShareApi", return_value=mock_share_api):
             DeleteAccess(mock_root, acc)
             mock_share_api.unaccess.assert_called_once()
 
@@ -53,7 +53,7 @@ class TestDeleteAccess:
         mock_share_api.unaccess.side_effect = Exception("500")
         acc = model.Access(Token="fe_tok", ShareToken="shr_abc", BackendMode="proxy")
 
-        with patch("zrok.access.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.access.ShareApi", return_value=mock_share_api):
             with pytest.raises(Exception, match="error deleting access"):
                 DeleteAccess(mock_root, acc)
 
@@ -68,7 +68,7 @@ class TestAccessContextManager:
 
         req = model.AccessRequest(ShareToken="shr_abc")
 
-        with patch("zrok.access.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.access.ShareApi", return_value=mock_share_api):
             with Access(mock_root, req) as acc:
                 assert acc.Token == "fe_tok"
             # unaccess should have been called on exit

--- a/sdk/python/tests/test_enable.py
+++ b/sdk/python/tests/test_enable.py
@@ -1,4 +1,4 @@
-"""Tests for zrok.environment.enable — enable() and disable()."""
+"""Tests for zrok2.environment.enable — enable() and disable()."""
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -38,10 +38,10 @@ class TestEnable:
         id_file = str(tmp_zrok_dir / "identities" / "environment.json")
 
         with patch.object(fresh_root, "Client", return_value=mock_client), \
-             patch("zrok.environment.enable.EnvironmentApi", return_value=mock_env_api), \
-             patch("zrok.environment.root.environmentFile", return_value=env_file), \
-             patch("zrok.environment.root.identitiesDir", return_value=id_dir), \
-             patch("zrok.environment.root.identityFile", return_value=id_file):
+             patch("zrok2.environment.enable.EnvironmentApi", return_value=mock_env_api), \
+             patch("zrok2.environment.root.environmentFile", return_value=env_file), \
+             patch("zrok2.environment.root.identitiesDir", return_value=id_dir), \
+             patch("zrok2.environment.root.identityFile", return_value=id_file):
             env = enable(fresh_root, "my-token", description="test host")
             assert env.Token == "my-token"
             assert env.ZitiIdentity == "new-ziti-id"
@@ -60,7 +60,7 @@ class TestEnable:
         mock_env_api.enable_with_http_info.side_effect = Exception("500 server error")
 
         with patch.object(fresh_root, "Client", return_value=mock_client), \
-             patch("zrok.environment.enable.EnvironmentApi", return_value=mock_env_api):
+             patch("zrok2.environment.enable.EnvironmentApi", return_value=mock_env_api):
             with pytest.raises(Exception, match="unable to enable environment"):
                 enable(fresh_root, "my-token")
         assert not fresh_root.IsEnabled()
@@ -78,9 +78,9 @@ class TestDisable:
         env_file = str(tmp_zrok_dir / "environment.json")
         id_file = str(tmp_zrok_dir / "identities" / "environment.json")
 
-        with patch("zrok.environment.enable.EnvironmentApi", return_value=mock_env_api), \
-             patch("zrok.environment.root.environmentFile", return_value=env_file), \
-             patch("zrok.environment.root.identityFile", return_value=id_file):
+        with patch("zrok2.environment.enable.EnvironmentApi", return_value=mock_env_api), \
+             patch("zrok2.environment.root.environmentFile", return_value=env_file), \
+             patch("zrok2.environment.root.identityFile", return_value=id_file):
             disable(mock_root)
             mock_env_api.disable_with_http_info.assert_called_once()
             assert not mock_root.IsEnabled()

--- a/sdk/python/tests/test_listing.py
+++ b/sdk/python/tests/test_listing.py
@@ -1,4 +1,4 @@
-"""Tests for zrok.listing — list_shares, list_accesses."""
+"""Tests for zrok2.listing — list_shares, list_accesses."""
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -28,7 +28,7 @@ class TestListShares:
         mock_res.shares = [mock_share]
         mock_metadata_api.list_shares.return_value = mock_res
 
-        with patch("zrok.listing.MetadataApi", return_value=mock_metadata_api):
+        with patch("zrok2.listing.MetadataApi", return_value=mock_metadata_api):
             shares = list_shares(mock_root)
             assert len(shares) == 1
             assert shares[0].Token == "shr_abc"
@@ -40,7 +40,7 @@ class TestListShares:
         mock_res.shares = []
         mock_metadata_api.list_shares.return_value = mock_res
 
-        with patch("zrok.listing.MetadataApi", return_value=mock_metadata_api):
+        with patch("zrok2.listing.MetadataApi", return_value=mock_metadata_api):
             shares = list_shares(mock_root)
             assert shares == []
 
@@ -50,7 +50,7 @@ class TestListShares:
         mock_res.shares = None
         mock_metadata_api.list_shares.return_value = mock_res
 
-        with patch("zrok.listing.MetadataApi", return_value=mock_metadata_api):
+        with patch("zrok2.listing.MetadataApi", return_value=mock_metadata_api):
             shares = list_shares(mock_root)
             assert shares == []
 
@@ -77,7 +77,7 @@ class TestListAccesses:
         mock_res.accesses = [mock_access]
         mock_metadata_api.list_accesses.return_value = mock_res
 
-        with patch("zrok.listing.MetadataApi", return_value=mock_metadata_api):
+        with patch("zrok2.listing.MetadataApi", return_value=mock_metadata_api):
             accesses = list_accesses(mock_root)
             assert len(accesses) == 1
             assert accesses[0].FrontendToken == "fe_tok"
@@ -89,6 +89,6 @@ class TestListAccesses:
         mock_res.accesses = []
         mock_metadata_api.list_accesses.return_value = mock_res
 
-        with patch("zrok.listing.MetadataApi", return_value=mock_metadata_api):
+        with patch("zrok2.listing.MetadataApi", return_value=mock_metadata_api):
             accesses = list_accesses(mock_root)
             assert accesses == []

--- a/sdk/python/tests/test_model.py
+++ b/sdk/python/tests/test_model.py
@@ -1,4 +1,4 @@
-"""Tests for zrok.model — dataclass construction and constants."""
+"""Tests for zrok2.model — dataclass construction and constants."""
 
 import zrok2.model as model
 

--- a/sdk/python/tests/test_name.py
+++ b/sdk/python/tests/test_name.py
@@ -1,4 +1,4 @@
-"""Tests for zrok.name — create_name, delete_name, list_names, list_namespaces."""
+"""Tests for zrok2.name — create_name, delete_name, list_names, list_namespaces."""
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -14,7 +14,7 @@ class TestCreateName:
     def test_create_name(self, mock_root):
         mock_share_api = MagicMock()
 
-        with patch("zrok.name.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.name.ShareApi", return_value=mock_share_api):
             entry = create_name(mock_root, "myname", namespace_token="ns1")
             assert entry.Name == "myname"
             assert entry.NamespaceToken == "ns1"
@@ -23,7 +23,7 @@ class TestCreateName:
     def test_create_name_default_namespace(self, mock_root):
         mock_share_api = MagicMock()
 
-        with patch("zrok.name.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.name.ShareApi", return_value=mock_share_api):
             entry = create_name(mock_root, "myname")
             assert entry.NamespaceToken == ""
 
@@ -36,7 +36,7 @@ class TestDeleteName:
     def test_delete_name(self, mock_root):
         mock_share_api = MagicMock()
 
-        with patch("zrok.name.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.name.ShareApi", return_value=mock_share_api):
             delete_name(mock_root, "myname", namespace_token="ns1")
             mock_share_api.delete_share_name_with_http_info.assert_called_once()
 
@@ -57,7 +57,7 @@ class TestListNames:
         mock_name.created_at = 1000
         mock_share_api.list_names_for_namespace.return_value = [mock_name]
 
-        with patch("zrok.name.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.name.ShareApi", return_value=mock_share_api):
             names = list_names(mock_root, namespace_token="ns1")
             assert len(names) == 1
             assert names[0].Name == "myname"
@@ -78,7 +78,7 @@ class TestListNames:
         mock_name.created_at = 0
         mock_share_api.list_names_for_namespace.return_value = [mock_name]
 
-        with patch("zrok.name.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.name.ShareApi", return_value=mock_share_api):
             names = list_names(mock_root)
             assert len(names) == 1
 
@@ -96,7 +96,7 @@ class TestListNamespaces:
         mock_ns.description = "Public namespace"
         mock_share_api.list_share_namespaces.return_value = [mock_ns]
 
-        with patch("zrok.name.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.name.ShareApi", return_value=mock_share_api):
             nss = list_namespaces(mock_root)
             assert len(nss) == 1
             assert nss[0].NamespaceToken == "ns1"
@@ -106,6 +106,6 @@ class TestListNamespaces:
         mock_share_api = MagicMock()
         mock_share_api.list_share_namespaces.return_value = []
 
-        with patch("zrok.name.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.name.ShareApi", return_value=mock_share_api):
             nss = list_namespaces(mock_root)
             assert nss == []

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1,0 +1,100 @@
+"""Tests for zrok2.proxy."""
+
+import http.server
+import socketserver
+import threading
+import urllib.parse
+
+import pytest
+
+from zrok2.model import Share
+from zrok2.proxy import ProxyShare, _target_url
+
+
+class ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+def _serve(handler_cls):
+    srv = ThreadingTCPServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    return srv
+
+
+def _proxy_share(target):
+    return ProxyShare(
+        root=None,
+        share=Share(Token="demo", FrontendEndpoints=[]),
+        target=target,
+    )
+
+
+def test_target_url_rejects_absolute_paths():
+    with pytest.raises(ValueError, match="absolute proxy paths"):
+        _target_url("http://127.0.0.1:19191/base/", "http://127.0.0.1:19190/metadata")
+
+    with pytest.raises(ValueError, match="absolute proxy paths"):
+        _target_url("http://127.0.0.1:19191/base/", "//127.0.0.1:19190/metadata")
+
+
+def test_proxy_rejects_encoded_absolute_url_path():
+    class MetadataHandler(http.server.BaseHTTPRequestHandler):
+        request_count = 0
+
+        def do_GET(self):
+            type(self).request_count += 1
+            if self.path == "/metadata":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"INTERNAL_METADATA_TOKEN")
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, fmt, *args):
+            pass
+
+    internal = _serve(MetadataHandler)
+    try:
+        target = "http://127.0.0.1:19191/base/"
+        client = _proxy_share(target)._create_app().test_client()
+        absolute_url = f"http://127.0.0.1:{internal.server_address[1]}/metadata"
+        encoded = "/" + urllib.parse.quote(absolute_url, safe="")
+
+        response = client.get(encoded)
+
+        assert response.status_code == 400
+        assert response.data != b"INTERNAL_METADATA_TOKEN"
+        assert MetadataHandler.request_count == 0
+    finally:
+        internal.shutdown()
+        internal.server_close()
+
+
+def test_proxy_forwards_relative_paths_to_configured_target():
+    class TargetHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/base/resource":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"target response")
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, fmt, *args):
+            pass
+
+    target = _serve(TargetHandler)
+    try:
+        target_url = f"http://127.0.0.1:{target.server_address[1]}/base/"
+        client = _proxy_share(target_url)._create_app().test_client()
+
+        response = client.get("/resource")
+
+        assert response.status_code == 200
+        assert response.data == b"target response"
+    finally:
+        target.shutdown()
+        target.server_close()

--- a/sdk/python/tests/test_root.py
+++ b/sdk/python/tests/test_root.py
@@ -1,4 +1,4 @@
-"""Tests for zrok.environment.root — Root, Load, Default, ApiEndpoint."""
+"""Tests for zrok2.environment.root — Root, Load, Default, ApiEndpoint."""
 
 import json
 import os
@@ -98,9 +98,9 @@ class TestRootPersistence:
         id_dir = str(tmp_zrok_dir / "identities")
         id_file = str(tmp_zrok_dir / "identities" / "environment.json")
 
-        with patch("zrok.environment.root.environmentFile", return_value=env_file), \
-             patch("zrok.environment.root.identitiesDir", return_value=id_dir), \
-             patch("zrok.environment.root.identityFile", return_value=id_file):
+        with patch("zrok2.environment.root.environmentFile", return_value=env_file), \
+             patch("zrok2.environment.root.identitiesDir", return_value=id_dir), \
+             patch("zrok2.environment.root.identityFile", return_value=id_file):
             env = Environment(Token="tok", ZitiIdentity="zid", ApiEndpoint="https://x.io")
             root.SetEnvironment(env)
 
@@ -125,15 +125,15 @@ class TestRootPersistence:
         root = Root(meta=Metadata(V=V, RootPath=str(tmp_zrok_dir)))
         env_file = str(tmp_zrok_dir / "environment.json")
         id_file = str(tmp_zrok_dir / "identities" / "environment.json")
-        with patch("zrok.environment.root.environmentFile", return_value=env_file), \
-             patch("zrok.environment.root.identityFile", return_value=id_file):
+        with patch("zrok2.environment.root.environmentFile", return_value=env_file), \
+             patch("zrok2.environment.root.identityFile", return_value=id_file):
             # Should not raise
             root.DeleteEnvironment()
 
 
 class TestDefault:
     def test_default_creates_root_with_version(self):
-        with patch("zrok.environment.root.rootDir", return_value="/tmp/fakezrok"):
+        with patch("zrok2.environment.root.rootDir", return_value="/tmp/fakezrok"):
             r = Default()
             assert r.meta.V == V
             assert r.meta.RootPath == "/tmp/fakezrok"
@@ -152,7 +152,7 @@ class TestClientVersionCheck:
         mock_response.status_code = 400
         mock_metadata_api.client_version_check_with_http_info.return_value = mock_response
 
-        with patch("zrok.environment.root.zrok.MetadataApi", return_value=mock_metadata_api):
+        with patch("zrok2.environment.root.zrok.MetadataApi", return_value=mock_metadata_api):
             with pytest.raises(Exception, match="Client version check failed"):
                 root.client_version_check(mock_client)
 
@@ -167,6 +167,6 @@ class TestClientVersionCheck:
         mock_response.status_code = 200
         mock_metadata_api.client_version_check_with_http_info.return_value = mock_response
 
-        with patch("zrok.environment.root.zrok.MetadataApi", return_value=mock_metadata_api):
+        with patch("zrok2.environment.root.zrok.MetadataApi", return_value=mock_metadata_api):
             # Should not raise
             root.client_version_check(mock_client)

--- a/sdk/python/tests/test_share.py
+++ b/sdk/python/tests/test_share.py
@@ -1,4 +1,4 @@
-"""Tests for zrok.share — CreateShare, DeleteShare, ModifyShare, GetShareDetail."""
+"""Tests for zrok2.share — CreateShare, DeleteShare, ModifyShare, GetShareDetail."""
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -40,10 +40,10 @@ class TestCreateShare:
             Frontends=["public"],
         )
 
-        with patch("zrok.share.ShareApi", return_value=mock_share_api), \
-             patch("zrok.share._ShareRequest__newPublicShare",
+        with patch("zrok2.share.ShareApi", return_value=mock_share_api), \
+             patch("zrok2.share._ShareRequest__newPublicShare",
                    return_value=_make_mock_api_share_request(), create=True) as _, \
-             patch("zrok.share.ShareRequest", return_value=_make_mock_api_share_request()):
+             patch("zrok2.share.ShareRequest", return_value=_make_mock_api_share_request()):
             share = CreateShare(mock_root, req)
             assert share.Token == "shr_abc123"
             assert share.FrontendEndpoints == ["https://abc123.share.zrok.io"]
@@ -62,8 +62,8 @@ class TestCreateShare:
             Target="tcp://localhost:25565",
         )
 
-        with patch("zrok.share.ShareApi", return_value=mock_share_api), \
-             patch("zrok.share.ShareRequest", return_value=_make_mock_api_share_request()):
+        with patch("zrok2.share.ShareApi", return_value=mock_share_api), \
+             patch("zrok2.share.ShareRequest", return_value=_make_mock_api_share_request()):
             share = CreateShare(mock_root, req)
             assert share.Token == "shr_priv"
 
@@ -92,8 +92,8 @@ class TestCreateShare:
             BasicAuth=["user1:pass1"],
         )
 
-        with patch("zrok.share.ShareApi", return_value=mock_share_api), \
-             patch("zrok.share.ShareRequest", return_value=_make_mock_api_share_request()):
+        with patch("zrok2.share.ShareApi", return_value=mock_share_api), \
+             patch("zrok2.share.ShareRequest", return_value=_make_mock_api_share_request()):
             share = CreateShare(mock_root, req)
             assert share.Token == "shr_auth"
 
@@ -103,7 +103,7 @@ class TestDeleteShare:
         mock_share_api = MagicMock()
         shr = model.Share(Token="shr_abc", FrontendEndpoints=[])
 
-        with patch("zrok.share.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.share.ShareApi", return_value=mock_share_api):
             DeleteShare(mock_root, shr)
             mock_share_api.unshare_with_http_info.assert_called_once()
 
@@ -112,7 +112,7 @@ class TestDeleteShare:
         mock_share_api.unshare_with_http_info.side_effect = Exception("404")
         shr = model.Share(Token="shr_bad", FrontendEndpoints=[])
 
-        with patch("zrok.share.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.share.ShareApi", return_value=mock_share_api):
             with pytest.raises(Exception, match="error deleting share"):
                 DeleteShare(mock_root, shr)
 
@@ -122,7 +122,7 @@ class TestReleaseReservedShare:
         mock_share_api = MagicMock()
         shr = model.Share(Token="shr_reserved", FrontendEndpoints=[])
 
-        with patch("zrok.share.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.share.ShareApi", return_value=mock_share_api):
             ReleaseReservedShare(mock_root, shr)
             mock_share_api.unshare_with_http_info.assert_called_once()
             call_args = mock_share_api.unshare_with_http_info.call_args
@@ -140,7 +140,7 @@ class TestModifyShare:
     def test_modify_share_adds_grants(self, mock_root):
         mock_share_api = MagicMock()
 
-        with patch("zrok.share.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.share.ShareApi", return_value=mock_share_api):
             ModifyShare(mock_root, "shr_abc", add_access_grants=["grant1"])
             mock_share_api.update_share_with_http_info.assert_called_once()
 
@@ -148,7 +148,7 @@ class TestModifyShare:
         mock_share_api = MagicMock()
         mock_share_api.update_share_with_http_info.side_effect = Exception("500")
 
-        with patch("zrok.share.ShareApi", return_value=mock_share_api):
+        with patch("zrok2.share.ShareApi", return_value=mock_share_api):
             with pytest.raises(Exception, match="error modifying share"):
                 ModifyShare(mock_root, "shr_abc", add_access_grants=["grant1"])
 
@@ -173,7 +173,7 @@ class TestGetShareDetail:
         mock_res.updated_at = 2000
         mock_metadata_api.get_share_detail.return_value = mock_res
 
-        with patch("zrok.share.MetadataApi", return_value=mock_metadata_api):
+        with patch("zrok2.share.MetadataApi", return_value=mock_metadata_api):
             detail = GetShareDetail(mock_root, "shr_abc")
             assert detail.Token == "shr_abc"
             assert detail.ShareMode == "public"

--- a/sdk/python/tests/test_status.py
+++ b/sdk/python/tests/test_status.py
@@ -1,4 +1,4 @@
-"""Tests for zrok.status — status()."""
+"""Tests for zrok2.status — status()."""
 
 from zrok2.status import status
 from zrok2.environment.root import Root


### PR DESCRIPTION
FIX: The Python SDK `ProxyShare` now rejects absolute proxy request paths before forwarding. This prevents a viewer from using an absolute URL path to make the proxy host request arbitrary internal or loopback services instead of the configured target.

FIX: Updated Python SDK unit tests to patch `zrok2.*` modules instead of the legacy `zrok.*` package path, allowing the non-integration test suite to pass against the v2 Python package layout.