### PR TITLE
metrics service influx version pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ FIX: The Python SDK `ProxyShare` now rejects absolute proxy request paths before
 
 FIX: Updated Python SDK unit tests to patch `zrok2.*` modules instead of the legacy `zrok.*` package path, allowing the non-integration test suite to pass against the v2 Python package layout.
 
+FIX: The zrok2 Docker Compose self-hosting metrics service now defaults to `influxdb:2.8-alpine` instead of the floating `influxdb:2-alpine` tag to avoid upstream image regressions. Docker Compose integration test failures now also include compose service status, container health details, and focused InfluxDB logs for faster diagnosis.
+
 FIX: The `zrok2 copy` drive sync path now rejects unsafe WebDAV and zrok drive paths before writing to a local filesystem target. Local drive sync operations are root-confined to prevent attacker-controlled paths or symlinks from writing, removing, moving, or timestamping files outside the selected destination while still allowing symlinks that resolve within the destination tree.
 
 FIX: Frontends configured with `interstitial.user_agent_prefixes` no longer suppress the interstitial page for all requests. The prefix list is now correctly evaluated as an allow-list of User-Agents that should receive the page; if the list is empty all User-Agents receive it, matching the documented behavior.

--- a/docker/compose/zrok2-instance/.env.example
+++ b/docker/compose/zrok2-instance/.env.example
@@ -60,6 +60,9 @@ ZROK2_DB_PASSWORD=changeme-db-password
 # Set to "true" to enable the metrics pipeline (RabbitMQ + InfluxDB).
 # ZROK2_METRICS_ENABLED=false
 
+# InfluxDB image. Pin by default to avoid regressions in the floating 2-alpine tag.
+# INFLUXDB_IMAGE=influxdb:2.8-alpine
+
 # InfluxDB admin password (must be 8+ characters).
 # ZROK2_INFLUX_PASSWORD=changeme-influx-password
 

--- a/docker/compose/zrok2-instance/compose.yml
+++ b/docker/compose/zrok2-instance/compose.yml
@@ -295,7 +295,7 @@ services:
     restart: unless-stopped
 
   influxdb:
-    image: influxdb:2-alpine
+    image: ${INFLUXDB_IMAGE:-influxdb:2.8-alpine}
     profiles: ["metrics"]
     environment:
       DOCKER_INFLUXDB_INIT_MODE: setup

--- a/docker/compose/zrok2-instance/dangerous.docker.test.bash
+++ b/docker/compose/zrok2-instance/dangerous.docker.test.bash
@@ -99,6 +99,14 @@ wait_for_port() {
 }
 
 dump_logs() {
+    log_info "compose service status:"
+    (cd "${COMPOSE_PROJECT_DIR}" && docker compose ps -a) 2>/dev/null || true
+    log_info "container health details:"
+    (cd "${COMPOSE_PROJECT_DIR}" && docker compose ps -aq | xargs -r docker inspect \
+        --format '{{.Name}} status={{.State.Status}} exit={{.State.ExitCode}} health={{json .State.Health}}') \
+        2>/dev/null || true
+    log_info "InfluxDB logs (last 200 lines):"
+    (cd "${COMPOSE_PROJECT_DIR}" && docker compose logs --tail=200 influxdb) 2>/dev/null || true
     log_info "container logs (last 100 lines each):"
     (cd "${COMPOSE_PROJECT_DIR}" && docker compose logs --tail=100) 2>/dev/null || true
 }


### PR DESCRIPTION
FIX: The zrok2 Docker Compose self-hosting metrics service now defaults to `influxdb:2.8-alpine` instead of the floating `influxdb:2-alpine` tag to avoid upstream image regressions. Docker Compose integration test failures now also include compose service status, container health details, and focused InfluxDB logs for faster diagnosis.