### PR TITLE
fix: update openziti intro link to 2.x path after version promotion

### DIFF
--- a/website/docs/concepts/private-shares.mdx
+++ b/website/docs/concepts/private-shares.mdx
@@ -32,7 +32,7 @@ connections using the `tunnel` backend. What matters is that access is private a
 who have your share token.
 
 The peer-to-peer capabilities of zrok are an important property of the underlying
-[OpenZiti](@openzitidocs/learn/introduction) network that zrok uses to provide connectivity between
+[OpenZiti](@openzitidocs/intro) network that zrok uses to provide connectivity between
 users and resources.
 
 To create and manage private shares, see [Manage shares with the agent](@zrokdocs/how-tos/agent/manage-shares).

--- a/website/docs/self-hosting/metrics-and-limits/configure-metrics.md
+++ b/website/docs/self-hosting/metrics-and-limits/configure-metrics.md
@@ -23,7 +23,7 @@ Configure the OpenZiti controller, metrics bridge, and zrok controller to collec
     ```
 
     Adjust `events/jsonLogger/handler/path` to wherever you want to send these events for ingestion into zrok. Consult
-    the [OpenZiti docs](@openzitidocs/learn/introduction) for additional options that control file rotation.
+    the [OpenZiti docs](@openzitidocs/intro) for additional options that control file rotation.
 
 2. Add the following to the `network` stanza of the OpenZiti controller configuration to increase the reporting
    frequency. By default, the OpenZiti events infrastructure reports and batches events in 1-minute buckets—too large an


### PR DESCRIPTION
fix: update openziti intro link to 2.x path after version promotion