### PR TITLE
remove public

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -5,6 +5,5 @@
         "silent": false
     },
     "cleanUrls": false,
-    "public": true,
     "ignoreCommand": "grep -qE '^(gh-pages)$' <<< ${VERCEL_GIT_COMMIT_REF} || git diff --quiet HEAD^ HEAD -- ../website/ ../docs/ ../**/*.md"
 }


### PR DESCRIPTION
The "public": true flag in vercel.json makes deployment source and logs publicly accessible and is a deprecated, file-only property. The unrecognized field caused Dependabot preview deployments to fail. Mirrors openziti/ziti-doc#1314.